### PR TITLE
Simplified counter example

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -3,9 +3,6 @@ export const FUEL_GREEN = '#00f58c';
 export const DEFAULT_CONTRACT = `contract;
 
 abi TestContract {
-    #[storage(write)]
-    fn initialize_counter(value: u64) -> u64;
-
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64;
 
@@ -18,12 +15,6 @@ storage {
 }
 
 impl TestContract for Contract {
-    #[storage(write)]
-    fn initialize_counter(value: u64) -> u64 {
-        storage.counter = value;
-        value
-    }
-
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64 {
         let incremented = storage.counter + amount;

--- a/projects/swaypad/src/main.sw
+++ b/projects/swaypad/src/main.sw
@@ -1,9 +1,6 @@
 contract;
 
 abi TestContract {
-    #[storage(write)]
-    fn initialize_counter(value: u64) -> u64;
-
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64;
 
@@ -16,12 +13,6 @@ storage {
 }
 
 impl TestContract for Contract {
-    #[storage(write)]
-    fn initialize_counter(value: u64) -> u64 {
-        storage.counter = value;
-        value
-    }
-
     #[storage(read, write)]
     fn increment_counter(amount: u64) -> u64 {
         let incremented = storage.counter + amount;


### PR DESCRIPTION
The original example had an initialize counter method which I found confusing as a first time user. The storage variable doesn't need to be "initialized", it can just be used, similar to EVM/Solidity.

The example here is just a simple increment and get, which I believe conforms more to the original counter examples from Solidity while also showcasing read + store, read storage annotation.