### PR TITLE
Copy CNAME file into build folder

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           cd app && npm ci && npm run build
           cp -r build ../build
+          cp ../CNAME ../build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Previously, after every deployment to gh pages, the CNAME file would be erased requiring someone to manually recreate it in order for sway-playground.org to serve the app. This change simply copies it into the build directory so that it's copied over to the gh-pages branch during deployment.