### PR TITLE
Only run test CI once for master

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,8 @@ name: Build and Test
 
 on:
   push:
+    branches-ignore:
+      - master
 
 env:
   NODE_VERSION: '16'


### PR DESCRIPTION
The deploy workflow for master does the build & test steps first, so there's no need to run this workflow on master.