### PR TITLE
Improve tooltip for copyable hex

### DIFF
--- a/app/src/components/Copyable.tsx
+++ b/app/src/components/Copyable.tsx
@@ -7,23 +7,25 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 export interface CopyableProps {
   value: string;
   label: string;
+  tooltip: string;
 }
 
 async function handleCopy(value: string) {
   await navigator.clipboard.writeText(value);
 }
 
-function Copyable({ value, label }: CopyableProps) {
+function Copyable({ value, label, tooltip }: CopyableProps) {
   return (
-    <div style={{ color: darkColors.gray6 }}>
-      {label}
-      <Tooltip title='Click to copy'>
-        <IconButton
-          disableRipple
-          onClick={() => handleCopy(value)}
-          aria-label='copy'>
-          <ContentCopyIcon style={{ fontSize: '14px' }} />
-        </IconButton>
+    <div
+      style={{ cursor: 'pointer', color: darkColors.gray6 }}
+      onClick={() => handleCopy(value)}>
+      <Tooltip title={`Click to copy ${tooltip}`}>
+        <span>
+          <span style={{ padding: '8px 0 8px' }}>{label}</span>
+          <IconButton disableRipple aria-label='copy'>
+            <ContentCopyIcon style={{ fontSize: '14px' }} />
+          </IconButton>
+        </span>
       </Tooltip>
     </div>
   );

--- a/app/src/components/shared.tsx
+++ b/app/src/components/shared.tsx
@@ -19,7 +19,13 @@ export const ButtonSpinner = () => (
   />
 );
 
-export const CopyableHex = ({ hex }: { hex: string }) => {
+export const CopyableHex = ({
+  hex,
+  tooltip,
+}: {
+  hex: string;
+  tooltip: string;
+}) => {
   const formattedHex = hex.slice(0, 6) + '...' + hex.slice(-4, hex.length);
-  return <Copyable value={hex} label={formattedHex} />;
+  return <Copyable value={hex} label={formattedHex} tooltip={tooltip} />;
 };

--- a/app/src/features/editor/hooks/useCompile.tsx
+++ b/app/src/features/editor/hooks/useCompile.tsx
@@ -12,7 +12,7 @@ function toResults(
   return [
     <div key={'bytecode'}>
       <b>Bytecode</b>:<br />
-      <CopyableHex hex={prefixedBytecode} />
+      <CopyableHex hex={prefixedBytecode} tooltip='bytecode' />
       <br />
       <br />
     </div>,

--- a/app/src/features/interact/components/ContractInterface.tsx
+++ b/app/src/features/interact/components/ContractInterface.tsx
@@ -60,7 +60,7 @@ export function ContractInterface({
           }}>
           Contract Interface
         </div>
-        <CopyableHex hex={contractId} />
+        <CopyableHex hex={contractId} tooltip='contract ID' />
       </div>
 
       {functionInterfaces}


### PR DESCRIPTION
Previously there was nothing indicating what this hex value is. I've updated it so there's a tooltip over the hex value that tells you what it is, and also made it clickable so users don't have to click the tiny icon to copy it.

Before:
![Aug-30-2023 12-13-00](https://github.com/FuelLabs/sway-playground/assets/47993817/b9d77a6a-be33-4498-bccc-61c61accce9f)

After:
![Aug-30-2023 12-12-56](https://github.com/FuelLabs/sway-playground/assets/47993817/db089382-e89f-4cc6-a0b8-db8316ba0179)
