### PR TITLE
Support for transpiling Solidity into Sway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ target
 build
 node_modules
 tmp
-projects
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ target
 build
 node_modules
 tmp
+projects
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 /certs/*
 build
 node_modules
+tmp
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ This will open http://localhost:3000 in your browser. By default, it will use th
 To test against the backend running locally, make this change in `app/src/constants.ts`:
 
 ```diff
--    export const SERVER_URI = 'https://api.sway-playground.org/compile';
--    // export const SERVER_URI = 'http://0.0.0.0:8080/compile';
-+    // export const SERVER_URI = 'https://api.sway-playground.org/compile';
-+    export const SERVER_URI = 'http://0.0.0.0:8080/compile';
+-    export const SERVER_URI = 'https://api.sway-playground.org';
+-    // export const SERVER_URI = 'http://0.0.0.0:8080';
++    // export const SERVER_URI = 'https://api.sway-playground.org';
++    export const SERVER_URI = 'http://0.0.0.0:8080';
 ```
 
 ## Contributing to Sway

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo run
 Alternatively, it can be run locally with Docker, as it is in the deployed environment.
 
 ```sh
-docker build -f deployment .
+docker build -f deployment/Dockerfile .
 docker run -p 8080:8080 -d <image-sha>
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ npm start
 
 This will open http://localhost:3000 in your browser. By default, it will use the production backend endpoint. 
 
-To test against the backend running locally, make this change in `app/src/features/editor/hooks/useCompile.tsx`:
+To test against the backend running locally, make this change in `app/src/constants.ts`:
 
 ```diff
--    const server_uri = 'https://api.sway-playground.org/compile';
--    // const server_uri = 'http://0.0.0.0:8080/compile';
-+    // const server_uri = 'https://api.sway-playground.org/compile';
-+    const server_uri = 'http://0.0.0.0:8080/compile';
+-    export const SERVER_URI = 'https://api.sway-playground.org/compile';
+-    // export const SERVER_URI = 'http://0.0.0.0:8080/compile';
++    // export const SERVER_URI = 'https://api.sway-playground.org/compile';
++    export const SERVER_URI = 'http://0.0.0.0:8080/compile';
 ```
 
 ## Contributing to Sway

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,7 @@
         "@mui/material": "^5.13.2",
         "@tanstack/react-query": "^4.24.9",
         "ace-builds": "^1.22.0",
+        "ace-mode-solidity": "^0.1.1",
         "ansicolor": "^1.1.100",
         "fuels": "^0.74",
         "react": "^18.2.0",
@@ -6533,6 +6534,11 @@
       "version": "1.32.6",
       "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.6.tgz",
       "integrity": "sha512-dO5BnyDOhCnznhOpILzXq4jqkbhRXxNkf3BuVTmyxGyRLrhddfdyk6xXgy+7A8LENrcYoFi/sIxMuH3qjNUN4w=="
+    },
+    "node_modules/ace-mode-solidity": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ace-mode-solidity/-/ace-mode-solidity-0.1.1.tgz",
+      "integrity": "sha512-OFDYb2DpSUdY/st3o+efbBof4e3M5zFXE8p1DwXNSoeGVT5+8/3KKwX6uhkuKipZ9VgqtPDSJLNcIY1+KSsrIw=="
     },
     "node_modules/acorn": {
       "version": "8.11.3",

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "@mui/material": "^5.13.2",
     "@tanstack/react-query": "^4.24.9",
     "ace-builds": "^1.22.0",
+    "ace-mode-solidity": "^0.1.1",
     "ansicolor": "^1.1.100",
     "fuels": "^0.74",
     "react": "^18.2.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -89,12 +89,12 @@ function App() {
 
   const onCompileClick = useCallback(() => {
     if (showSolidity) {
+      // Transpile the Solidity code before compiling.
       setCodeToTranspile(solidityCode);
-    }
-    if (!showSolidity) {
+    } else {
       setCodeToCompile(swayCode);
     }
-  }, [showSolidity, swayCode, setCodeToCompile, updateLog]);
+  }, [showSolidity, swayCode, solidityCode, setCodeToCompile, updateLog]);
 
   useTranspile(codeToTranspile, setCodeToCompile, onSwayCodeChange, setError, updateLog);
   useCompile(codeToCompile, setError, setIsCompiled, updateLog, toolchain);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import SwayEditor from './features/editor/components/SwayEditor';
 import ActionToolbar from './features/toolbar/components/ActionToolbar';
 import LogView from './features/editor/components/LogView';
 import { useCompile } from './features/editor/hooks/useCompile';
@@ -13,8 +12,8 @@ import {
 import InteractionDrawer from './features/interact/components/InteractionDrawer';
 import { useLog } from './features/editor/hooks/useLog';
 import { Toolchain } from './features/editor/components/ToolchainDropdown';
-import SolidityEditor from './features/editor/components/SolidityEditor';
 import { useTranspile } from './features/editor/hooks/useTranspile';
+import EditorView from './features/editor/components/EditorView';
 
 const DRAWER_WIDTH = '40vw';
 
@@ -96,7 +95,13 @@ function App() {
     }
   }, [showSolidity, swayCode, solidityCode, setCodeToCompile, updateLog]);
 
-  useTranspile(codeToTranspile, setCodeToCompile, onSwayCodeChange, setError, updateLog);
+  useTranspile(
+    codeToTranspile,
+    setCodeToCompile,
+    onSwayCodeChange,
+    setError,
+    updateLog
+  );
   useCompile(codeToCompile, setError, setIsCompiled, updateLog, toolchain);
 
   return (
@@ -126,29 +131,15 @@ function App() {
           display: 'flex',
           flexDirection: 'column',
         }}>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            // TODO
-            // resize: 'vertical',
-            // overflow: 'auto'
-          }}>
-          {showSolidity && <div style={{ flex: 1, marginRight: '1rem' }}>
-            <SolidityEditor
-              code={solidityCode}
-              onChange={onSolidityCodeChange}
-            />
-          </div>}
-          <div style={{ flex: 1 }}>
-            <SwayEditor
-              code={swayCode}
-              onChange={onSwayCodeChange}
-              toolchain={toolchain}
-              setToolchain={setToolchain}
-            />
-          </div>
-        </div>
+        <EditorView
+          swayCode={swayCode}
+          onSwayCodeChange={onSwayCodeChange}
+          solidityCode={solidityCode}
+          onSolidityCodeChange={onSolidityCodeChange}
+          toolchain={toolchain}
+          setToolchain={setToolchain}
+          showSolidity={showSolidity}
+        />
         <LogView results={log} />
       </div>
       <InteractionDrawer

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,7 +5,7 @@ import { useCompile } from './features/editor/hooks/useCompile';
 import { DeployState } from './utils/types';
 import {
   loadSolidityCode,
-  loadSwayCode as loadSwayCode,
+  loadSwayCode,
   saveSolidityCode,
   saveSwayCode,
 } from './utils/localStorage';
@@ -93,7 +93,7 @@ function App() {
     } else {
       setCodeToCompile(swayCode);
     }
-  }, [showSolidity, swayCode, solidityCode, setCodeToCompile, updateLog]);
+  }, [showSolidity, swayCode, solidityCode, setCodeToCompile, setCodeToTranspile]);
 
   useTranspile(
     codeToTranspile,

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,5 +1,9 @@
 export const FUEL_GREEN = '#00f58c';
 
+// TODO: Determine the URL based on the NODE_ENV.
+export const SERVER_URI = 'https://api.sway-playground.org/compile';
+// export const SERVER_URI = 'http://0.0.0.0:8080/transpile';
+
 export const DEFAULT_SWAY_CONTRACT = `contract;
 
 abi TestContract {
@@ -50,4 +54,3 @@ contract Counter {
         count -= 1;
     }
 }`;
-

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,6 +1,6 @@
 export const FUEL_GREEN = '#00f58c';
 
-export const DEFAULT_CONTRACT = `contract;
+export const DEFAULT_SWAY_CONTRACT = `contract;
 
 abi TestContract {
     #[storage(read, write)]
@@ -27,3 +27,27 @@ impl TestContract for Contract {
         storage.counter.read()
     }
 }`;
+
+export const DEFAULT_SOLIDITY_CONTRACT = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract Counter {
+    uint256 public count;
+
+    // Function to get the current count
+    function get_counter() public view returns (uint256) {
+        return count;
+    }
+
+    // Function to increment count by 1
+    function increment_counter() public {
+        count += 1;
+    }
+
+    // Function to decrement count by 1
+    function dec() public {
+        // This function will fail if count = 0
+        count -= 1;
+    }
+}`;
+

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,8 +1,8 @@
 export const FUEL_GREEN = '#00f58c';
 
 // TODO: Determine the URL based on the NODE_ENV.
-export const SERVER_URI = 'https://api.sway-playground.org/compile';
-// export const SERVER_URI = 'http://0.0.0.0:8080/transpile';
+// export const SERVER_URI = 'https://api.sway-playground.org';
+export const SERVER_URI = 'http://0.0.0.0:8080';
 
 export const DEFAULT_SWAY_CONTRACT = `contract;
 
@@ -32,14 +32,13 @@ impl TestContract for Contract {
     }
 }`;
 
-export const DEFAULT_SOLIDITY_CONTRACT = `// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+export const DEFAULT_SOLIDITY_CONTRACT = `pragma solidity ^0.8.24;
 
 contract Counter {
-    uint256 public count;
+    uint64 public count;
 
     // Function to get the current count
-    function get_counter() public view returns (uint256) {
+    function get_counter() public view returns (uint64) {
         return count;
     }
 

--- a/app/src/features/editor/components/ActionOverlay.tsx
+++ b/app/src/features/editor/components/ActionOverlay.tsx
@@ -6,8 +6,8 @@ import Tooltip from '@mui/material/Tooltip';
 
 export interface ActionOverlayProps {
   handleReset: () => void;
-  toolchain: Toolchain;
-  setToolchain: (toolchain: Toolchain) => void;
+  toolchain?: Toolchain;
+  setToolchain?: (toolchain: Toolchain) => void;
 }
 
 function ActionOverlay({
@@ -25,7 +25,7 @@ function ActionOverlay({
           zIndex: 1,
           pointerEvents: 'none',
         }}>
-        <ToolchainDropdown
+        {(toolchain && setToolchain) && <ToolchainDropdown
           style={{
             position: 'absolute',
             right: '68px',
@@ -34,7 +34,7 @@ function ActionOverlay({
           }}
           toolchain={toolchain}
           setToolchain={setToolchain}
-        />
+        />}
         <div>
           <Tooltip placement='top' title={'Reset the editor'}>
             <IconButton

--- a/app/src/features/editor/components/EditorView.tsx
+++ b/app/src/features/editor/components/EditorView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import SolidityEditor from './SolidityEditor';
 import SwayEditor from './SwayEditor';
 import { Toolchain } from './ToolchainDropdown';

--- a/app/src/features/editor/components/EditorView.tsx
+++ b/app/src/features/editor/components/EditorView.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef } from 'react';
+import SolidityEditor from './SolidityEditor';
+import SwayEditor from './SwayEditor';
+import { Toolchain } from './ToolchainDropdown';
+
+export interface EditorViewProps {
+  swayCode: string;
+  onSwayCodeChange: (value: string) => void;
+  solidityCode: string;
+  onSolidityCodeChange: (value: string) => void;
+  toolchain: Toolchain;
+  setToolchain: (toolchain: Toolchain) => void;
+  showSolidity: boolean;
+}
+
+function EditorView({
+  swayCode,
+  solidityCode,
+  onSolidityCodeChange,
+  onSwayCodeChange,
+  toolchain,
+  setToolchain,
+  showSolidity,
+}: EditorViewProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        height: '50vh',
+        minHeight: '10vh',
+        maxHeight: '80vh',
+        position: 'relative',
+        resize: 'vertical',
+        overflow: 'auto',
+      }}>
+      {showSolidity && (
+        <SolidityEditor code={solidityCode} onChange={onSolidityCodeChange} />
+      )}
+      <SwayEditor
+        code={swayCode}
+        onChange={onSwayCodeChange}
+        toolchain={toolchain}
+        setToolchain={setToolchain}
+      />
+    </div>
+  );
+}
+
+export default EditorView;

--- a/app/src/features/editor/components/SolidityEditor.tsx
+++ b/app/src/features/editor/components/SolidityEditor.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import AceEditor from 'react-ace';
+import 'ace-builds/webpack-resolver';
+import 'ace-builds/src-noconflict/mode-rust';
+import 'ace-builds/src-noconflict/theme-chrome';
+import { StyledBorder } from '../../../components/shared';
+import 'ace-mode-solidity/build/remix-ide/mode-solidity';
+import ActionOverlay from './ActionOverlay';
+import { DEFAULT_SOLIDITY_CONTRACT } from '../../../constants';
+
+export interface SolidityEditorProps {
+  code: string;
+  onChange: (value: string) => void;
+}
+
+function SolidityEditor({ code, onChange }: SolidityEditorProps) {
+  return (
+    <div>
+      <ActionOverlay handleReset={() => onChange(DEFAULT_SOLIDITY_CONTRACT)} />
+      <StyledBorder>
+        <AceEditor
+          style={{
+            width: '100%',
+            resize: 'vertical',
+            minHeight: '10vh',
+            maxHeight: '80vh',
+          }}
+          mode='solidity'
+          theme='chrome'
+          name='editor'
+          fontSize='14px'
+          onChange={onChange}
+          value={code}
+          editorProps={{ $blockScrolling: true }}
+        />
+      </StyledBorder>
+    </div>
+  );
+}
+
+export default SolidityEditor;

--- a/app/src/features/editor/components/SolidityEditor.tsx
+++ b/app/src/features/editor/components/SolidityEditor.tsx
@@ -15,26 +15,22 @@ export interface SolidityEditorProps {
 
 function SolidityEditor({ code, onChange }: SolidityEditorProps) {
   return (
-    <div>
+    <StyledBorder style={{ flex: 1, marginRight: '1rem' }}>
       <ActionOverlay handleReset={() => onChange(DEFAULT_SOLIDITY_CONTRACT)} />
-      <StyledBorder>
-        <AceEditor
-          style={{
-            width: '100%',
-            resize: 'vertical',
-            minHeight: '10vh',
-            maxHeight: '80vh',
-          }}
-          mode='solidity'
-          theme='chrome'
-          name='editor'
-          fontSize='14px'
-          onChange={onChange}
-          value={code}
-          editorProps={{ $blockScrolling: true }}
-        />
-      </StyledBorder>
-    </div>
+      <AceEditor
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        mode='solidity'
+        theme='chrome'
+        name='editor'
+        fontSize='14px'
+        onChange={onChange}
+        value={code}
+        editorProps={{ $blockScrolling: true }}
+      />
+    </StyledBorder>
   );
 }
 

--- a/app/src/features/editor/components/SwayEditor.tsx
+++ b/app/src/features/editor/components/SwayEditor.tsx
@@ -15,32 +15,33 @@ export interface SwayEditorProps {
   setToolchain: (toolchain: Toolchain) => void;
 }
 
-function SwayEditor({ code, onChange, toolchain, setToolchain }: SwayEditorProps) {
+function SwayEditor({
+  code,
+  onChange,
+  toolchain,
+  setToolchain,
+}: SwayEditorProps) {
   return (
-    <div>
+    <StyledBorder style={{ flex: 1 }}>
       <ActionOverlay
         handleReset={() => onChange(DEFAULT_SWAY_CONTRACT)}
         toolchain={toolchain}
         setToolchain={setToolchain}
       />
-      <StyledBorder>
-        <AceEditor
-          style={{
-            width: '100%',
-            resize: 'vertical',
-            minHeight: '10vh',
-            maxHeight: '80vh',
-          }}
-          mode='rust'
-          theme='chrome'
-          name='editor'
-          fontSize='14px'
-          onChange={onChange}
-          value={code}
-          editorProps={{ $blockScrolling: true }}
-        />
-      </StyledBorder>
-    </div>
+      <AceEditor
+        style={{
+          width: '100%',
+          height: '100%',
+        }}
+        mode='rust'
+        theme='chrome'
+        name='editor'
+        fontSize='14px'
+        onChange={onChange}
+        value={code}
+        editorProps={{ $blockScrolling: true }}
+      />
+    </StyledBorder>
   );
 }
 

--- a/app/src/features/editor/components/SwayEditor.tsx
+++ b/app/src/features/editor/components/SwayEditor.tsx
@@ -5,21 +5,21 @@ import 'ace-builds/src-noconflict/mode-rust';
 import 'ace-builds/src-noconflict/theme-chrome';
 import { StyledBorder } from '../../../components/shared';
 import ActionOverlay from './ActionOverlay';
-import { DEFAULT_CONTRACT } from '../../../constants';
+import { DEFAULT_SWAY_CONTRACT } from '../../../constants';
 import { Toolchain } from './ToolchainDropdown';
 
-export interface EditorProps {
+export interface SwayEditorProps {
   code: string;
   onChange: (value: string) => void;
   toolchain: Toolchain;
   setToolchain: (toolchain: Toolchain) => void;
 }
 
-function Editor({ code, onChange, toolchain, setToolchain }: EditorProps) {
+function SwayEditor({ code, onChange, toolchain, setToolchain }: SwayEditorProps) {
   return (
     <div>
       <ActionOverlay
-        handleReset={() => onChange(DEFAULT_CONTRACT)}
+        handleReset={() => onChange(DEFAULT_SWAY_CONTRACT)}
         toolchain={toolchain}
         setToolchain={setToolchain}
       />
@@ -44,4 +44,4 @@ function Editor({ code, onChange, toolchain, setToolchain }: EditorProps) {
   );
 }
 
-export default Editor;
+export default SwayEditor;

--- a/app/src/features/editor/hooks/useCompile.tsx
+++ b/app/src/features/editor/hooks/useCompile.tsx
@@ -34,7 +34,7 @@ export function useCompile(
   onError: (error: string | undefined) => void,
   setIsCompiled: (isCompiled: boolean) => void,
   setResults: (entry: React.ReactElement[]) => void,
-  toolchain: Toolchain,
+  toolchain: Toolchain
 ) {
   const [serverError, setServerError] = useState<boolean>(false);
   const [version, setVersion] = useState<string | undefined>();
@@ -50,7 +50,7 @@ export function useCompile(
     }
     setResults([<>Compiling Sway contract...</>]);
 
-    const request = new Request(SERVER_URI, {
+    const request = new Request(`${SERVER_URI}/compile`, {
       method: 'POST',
       body: JSON.stringify({
         contract: code,

--- a/app/src/features/editor/hooks/useCompile.tsx
+++ b/app/src/features/editor/hooks/useCompile.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../utils/localStorage';
 import { CopyableHex } from '../../../components/shared';
 import { Toolchain } from '../components/ToolchainDropdown';
+import { SERVER_URI } from '../../../constants';
 
 function toResults(
   prefixedBytecode: string,
@@ -49,10 +50,7 @@ export function useCompile(
     }
     setResults([<>Compiling Sway contract...</>]);
 
-    // TODO: Determine the URL based on the NODE_ENV.
-    // const server_uri = 'https://api.sway-playground.org/compile';
-    const server_uri = 'http://0.0.0.0:8080/compile';
-    const request = new Request(server_uri, {
+    const request = new Request(SERVER_URI, {
       method: 'POST',
       body: JSON.stringify({
         contract: code,
@@ -96,7 +94,6 @@ export function useCompile(
         }
       })
       .catch(() => {
-        console.error('Unexpected error compiling contract.');
         setServerError(true);
       });
     setIsCompiled(true);

--- a/app/src/features/editor/hooks/useCompile.tsx
+++ b/app/src/features/editor/hooks/useCompile.tsx
@@ -33,7 +33,7 @@ export function useCompile(
   onError: (error: string | undefined) => void,
   setIsCompiled: (isCompiled: boolean) => void,
   setResults: (entry: React.ReactElement[]) => void,
-  toolchain: Toolchain
+  toolchain: Toolchain,
 ) {
   const [serverError, setServerError] = useState<boolean>(false);
   const [version, setVersion] = useState<string | undefined>();
@@ -47,12 +47,11 @@ export function useCompile(
       setResults([<>Add some code to compile.</>]);
       return;
     }
-
-    setResults([<>Compiling...</>]);
+    setResults([<>Compiling Sway contract...</>]);
 
     // TODO: Determine the URL based on the NODE_ENV.
-    const server_uri = 'https://api.sway-playground.org/compile';
-    // const server_uri = 'http://0.0.0.0:8080/compile';
+    // const server_uri = 'https://api.sway-playground.org/compile';
+    const server_uri = 'http://0.0.0.0:8080/compile';
     const request = new Request(server_uri, {
       method: 'POST',
       body: JSON.stringify({
@@ -71,7 +70,7 @@ export function useCompile(
       })
       .then((response) => {
         const { error, forcVersion } = response;
-        if (error.length) {
+        if (error) {
           // Preserve the ANSI color codes from the compiler output.
           let parsedAnsi = ansicolor.parse(error);
           let results = parsedAnsi.spans.map((span, i) => {

--- a/app/src/features/editor/hooks/useTranspile.tsx
+++ b/app/src/features/editor/hooks/useTranspile.tsx
@@ -1,11 +1,7 @@
 import styled from '@emotion/styled';
 import ansicolor from 'ansicolor';
 import React, { useState, useEffect } from 'react';
-import {
-  saveAbi,
-  saveBytecode,
-  saveStorageSlots,
-} from '../../../utils/localStorage';
+import { SERVER_URI } from '../../../constants';
 
 export function useTranspile(
   code: string | undefined,
@@ -27,10 +23,7 @@ export function useTranspile(
       </>,
     ]);
 
-    // TODO: Determine the URL based on the NODE_ENV.
-    // const server_uri = 'https://api.sway-playground.org/compile';
-    const server_uri = 'http://0.0.0.0:8080/transpile';
-    const request = new Request(server_uri, {
+    const request = new Request(SERVER_URI, {
       method: 'POST',
       body: JSON.stringify({
         contract: code,
@@ -67,10 +60,9 @@ export function useTranspile(
         }
       })
       .catch(() => {
-        console.error('Unexpected error transpiling contract.');
         setServerError(true);
       });
-  }, [code, setResults]);
+  }, [code, setResults, onSwayCodeChange, setCodeToCompile]);
 
   useEffect(() => {
     if (serverError) {

--- a/app/src/features/editor/hooks/useTranspile.tsx
+++ b/app/src/features/editor/hooks/useTranspile.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import ansicolor from 'ansicolor';
+import React, { useState, useEffect } from 'react';
+import {
+  saveAbi,
+  saveBytecode,
+  saveStorageSlots,
+} from '../../../utils/localStorage';
+
+export function useTranspile(
+  code: string | undefined,
+  setCodeToCompile: (code: string | undefined) => void,
+  onSwayCodeChange: (code: string) => void,
+  onError: (error: string | undefined) => void,
+  setResults: (entry: React.ReactElement[]) => void
+) {
+  const [serverError, setServerError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!code) {
+      return;
+    }
+    setResults([
+      <>
+        Transpiling Solidity code with{' '}
+        <a href='https://github.com/camden-smallwood/charcoal'>charcoal</a>...
+      </>,
+    ]);
+
+    // TODO: Determine the URL based on the NODE_ENV.
+    // const server_uri = 'https://api.sway-playground.org/compile';
+    const server_uri = 'http://0.0.0.0:8080/transpile';
+    const request = new Request(server_uri, {
+      method: 'POST',
+      body: JSON.stringify({
+        contract: code,
+        lanaguage: 'solidity',
+      }),
+    });
+
+    fetch(request)
+      .then((response) => {
+        if (response.status < 400) {
+          return response.json();
+        } else {
+          setServerError(true);
+        }
+      })
+      .then((response) => {
+        const { error, swayContract } = response;
+        if (error) {
+          // Preserve the ANSI color codes from the compiler output.
+          let parsedAnsi = ansicolor.parse(error);
+          let results = parsedAnsi.spans.map((span, i) => {
+            const { text, css } = span;
+            const Span = styled.span`
+              ${css}
+            `;
+            return <Span key={`${i}-${text}`}>{text}</Span>;
+          });
+          setResults(results);
+        } else {
+          // Tell the useCompile hook to start compiling.
+          onSwayCodeChange(swayContract);
+          setCodeToCompile(swayContract);
+          setResults([<>Successfully transpiled Solidity contract to Sway.</>]);
+        }
+      })
+      .catch(() => {
+        console.error('Unexpected error transpiling contract.');
+        setServerError(true);
+      });
+  }, [code, setResults]);
+
+  useEffect(() => {
+    if (serverError) {
+      onError(
+        'There was an unexpected error transpiling your contract. Please try again.'
+      );
+    }
+  }, [serverError, onError]);
+}

--- a/app/src/features/editor/hooks/useTranspile.tsx
+++ b/app/src/features/editor/hooks/useTranspile.tsx
@@ -23,7 +23,7 @@ export function useTranspile(
       </>,
     ]);
 
-    const request = new Request(SERVER_URI, {
+    const request = new Request(`${SERVER_URI}/transpile`, {
       method: 'POST',
       body: JSON.stringify({
         contract: code,

--- a/app/src/features/toolbar/components/ActionToolbar.tsx
+++ b/app/src/features/toolbar/components/ActionToolbar.tsx
@@ -19,6 +19,8 @@ export interface ActionToolbarProps {
   setDeployState: (state: DeployState) => void;
   drawerOpen: boolean;
   setDrawerOpen: (open: boolean) => void;
+  showSolidity: boolean;
+  setShowSolidity: (open: boolean) => void;
   updateLog: (entry: string) => void;
 }
 
@@ -30,6 +32,8 @@ function ActionToolbar({
   setDeployState,
   drawerOpen,
   setDrawerOpen,
+  showSolidity,
+  setShowSolidity,
   updateLog,
 }: ActionToolbarProps) {
   return (
@@ -65,6 +69,16 @@ function ActionToolbar({
           deployState !== DeployState.DEPLOYED
             ? 'A contract must be deployed to interact with it on-chain'
             : 'Interact with the contract ABI'
+        }
+      />
+      <SecondaryButton
+        header={true}
+        onClick={() => setShowSolidity(!showSolidity)}
+        text='SOLIDITY'
+        tooltip={
+          showSolidity
+            ? 'Hide the Solidity editor'
+            : 'Show the Solidity editor to transpile Solidity to Sway'
         }
       />
       <SecondaryButton

--- a/app/src/utils/localStorage.ts
+++ b/app/src/utils/localStorage.ts
@@ -1,9 +1,10 @@
-import { DEFAULT_CONTRACT } from '../constants';
+import { DEFAULT_SWAY_CONTRACT, DEFAULT_SOLIDITY_CONTRACT } from '../constants';
 
 const STORAGE_ABI_KEY = 'playground_abi';
 const STORAGE_SLOTS_KEY = 'playground_slots';
 const STORAGE_BYTECODE_KEY = 'playground_bytecode';
 const STORAGE_CONTRACT_KEY = 'playground_contract';
+const STORAGE_SOLIDITY_CONTRACT_KEY = 'playground_solidity_contract';
 
 export function saveAbi(abi: string) {
   localStorage.setItem(STORAGE_ABI_KEY, abi);
@@ -29,10 +30,18 @@ export function loadBytecode() {
   return localStorage.getItem(STORAGE_BYTECODE_KEY) || '';
 }
 
-export function saveCode(code: string) {
+export function saveSwayCode(code: string) {
   localStorage.setItem(STORAGE_CONTRACT_KEY, code);
 }
 
-export function loadCode() {
-  return localStorage.getItem(STORAGE_CONTRACT_KEY) ?? DEFAULT_CONTRACT;
+export function saveSolidityCode(code: string) {
+  localStorage.setItem(STORAGE_SOLIDITY_CONTRACT_KEY, code);
+}
+
+export function loadSwayCode() {
+  return localStorage.getItem(STORAGE_CONTRACT_KEY) ?? DEFAULT_SWAY_CONTRACT;
+}
+
+export function loadSolidityCode() {
+  return localStorage.getItem(STORAGE_SOLIDITY_CONTRACT_KEY) ?? DEFAULT_SOLIDITY_CONTRACT;
 }

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,7 +1,8 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.70 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.76 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     lld \
@@ -10,12 +11,17 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Build sway-playground
 FROM chef as planner
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
+
+# Install charcoal
+RUN cargo install --git https://github.com/camden-smallwood/charcoal.git --rev f6338bf318500dd6977af813c37f66c504925c44
+
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json
 # Build our project dependecies, not our application!
@@ -41,10 +47,11 @@ COPY --from=builder /build/target/debug/sway-playground .
 COPY --from=builder /build/target/debug/sway-playground.d .
 COPY --from=builder /build/Rocket.toml .
 COPY --from=builder /build/projects projects
+COPY --from=builder /usr/local/cargo/bin/charcoal /bin
 
 # Install fuelup
 RUN curl -fsSL https://install.fuel.network/ | sh -s -- --no-modify-path
-ENV PATH="/root/.fuelup/bin:$HOME/.cargo/bin:$PATH"
+ENV PATH="/root/.fuelup/bin:$PATH"
 
 # Install all fuel toolchains
 RUN fuelup toolchain install latest
@@ -54,10 +61,6 @@ RUN fuelup toolchain install beta-2
 RUN fuelup toolchain install beta-3
 RUN fuelup toolchain install beta-4
 RUN fuelup toolchain install beta-5
-
-# Install charcoal
-RUN git clone https://github.com/camden-smallwood/charcoal.git
-RUN cargo install --path charcoal
 
 EXPOSE 8080
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -43,8 +43,8 @@ COPY --from=builder /build/Rocket.toml .
 COPY --from=builder /build/projects projects
 
 # Install fuelup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh -s -- --no-modify-path
-ENV PATH="/root/.fuelup/bin:$PATH"
+RUN curl -fsSL https://install.fuel.network/ | sh -s -- --no-modify-path
+ENV PATH="/root/.fuelup/bin:$HOME/.cargo/bin:$PATH"
 
 # Install all fuel toolchains
 RUN fuelup toolchain install latest
@@ -54,6 +54,10 @@ RUN fuelup toolchain install beta-2
 RUN fuelup toolchain install beta-3
 RUN fuelup toolchain install beta-4
 RUN fuelup toolchain install beta-5
+
+# Install charcoal
+RUN git clone https://github.com/camden-smallwood/charcoal.git
+RUN cargo install --path charcoal
 
 EXPOSE 8080
 

--- a/src/compilation/mod.rs
+++ b/src/compilation/mod.rs
@@ -2,10 +2,13 @@ mod swaypad;
 mod tooling;
 
 use self::{
-    swaypad::{ create_project, remove_project, write_main_file},
+    swaypad::{create_project, remove_project, write_main_file},
     tooling::{build_project, check_forc_version, switch_fuel_toolchain},
 };
-use crate::{types::CompileResponse, util::{read_file_contents, clean_error_content}};
+use crate::{
+    types::CompileResponse,
+    util::{clean_error_content, read_file_contents},
+};
 use hex::encode;
 use std::fs::read_to_string;
 

--- a/src/compilation/mod.rs
+++ b/src/compilation/mod.rs
@@ -1,14 +1,15 @@
-use crate::{types::CompileResponse, util::read_file_contents};
+mod swaypad;
+mod tooling;
 
 use self::{
-    swaypad::{clean_error_content, create_project, remove_project, write_main_file},
+    swaypad::{ create_project, remove_project, write_main_file},
     tooling::{build_project, check_forc_version, switch_fuel_toolchain},
 };
+use crate::{types::CompileResponse, util::{read_file_contents, clean_error_content}};
 use hex::encode;
 use std::fs::read_to_string;
 
-pub mod swaypad;
-pub mod tooling;
+const FILE_NAME: &str = "main.sw";
 
 /// Build and destroy a project.
 pub fn build_and_destroy_project(contract: String, toolchain: String) -> CompileResponse {
@@ -18,8 +19,8 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
             abi: "".to_string(),
             bytecode: "".to_string(),
             storage_slots: "".to_string(),
-            error: "No contract.".to_string(),
             forc_version: "".to_string(),
+            error: Some("No contract.".to_string()),
         };
     }
 
@@ -52,11 +53,11 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
 
         // Return the abi, bin, empty error message, and forc version.
         CompileResponse {
-            abi: clean_error_content(abi),
-            bytecode: clean_error_content(encode(bin)),
+            abi: clean_error_content(abi, FILE_NAME),
+            bytecode: clean_error_content(encode(bin), FILE_NAME),
             storage_slots: String::from_utf8_lossy(&storage_slots).into(),
-            error: String::from(""),
             forc_version,
+            error: None,
         }
     } else {
         // Get the error message presented in the console output.
@@ -76,7 +77,7 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
             abi: String::from(""),
             bytecode: String::from(""),
             storage_slots: String::from(""),
-            error: clean_error_content(trunc),
+            error: Some(clean_error_content(trunc, FILE_NAME)),
             forc_version,
         }
     }

--- a/src/compilation/swaypad.rs
+++ b/src/compilation/swaypad.rs
@@ -1,7 +1,7 @@
 use fs_extra::dir::{copy, CopyOptions};
 use nanoid::nanoid;
 use regex::Regex;
-use std::fs::{create_dir, remove_dir_all, File};
+use std::fs::{ remove_dir_all, File, create_dir_all};
 use std::io::prelude::*;
 
 const PROJECTS: &str = "projects";
@@ -12,7 +12,7 @@ pub fn create_project() -> Result<std::string::String, fs_extra::error::Error> {
     let project_name = nanoid!();
 
     // Create a new directory for the project.
-    create_dir(format!("{PROJECTS}/{project_name}"))?;
+    create_dir_all(format!("{PROJECTS}/{project_name}"))?;
 
     // Setup the copy options for copying the template project to the new dir.
     let options = CopyOptions {
@@ -37,20 +37,11 @@ pub fn create_project() -> Result<std::string::String, fs_extra::error::Error> {
 
 /// Remove a project from the projects dir.
 pub fn remove_project(project_name: String) -> std::io::Result<()> {
-    remove_dir_all(format!("{PROJECTS}/{project_name}"))?;
-    Ok(())
+    remove_dir_all(format!("{PROJECTS}/{project_name}"))
 }
 
 /// Write the main sway file to a project.
 pub fn write_main_file(project_name: String, contract: &[u8]) -> std::io::Result<()> {
     let mut file = File::create(format!("{PROJECTS}/{project_name}/src/main.sw"))?;
-    file.write_all(contract)?;
-    Ok(())
-}
-
-/// This is a hack and should be made reletive or removed.
-pub fn clean_error_content(content: String) -> std::string::String {
-    let path_pattern = Regex::new(r"(/).*(/main.sw)").unwrap();
-
-    path_pattern.replace_all(&content, "/main.sw").to_string()
+    file.write_all(contract)
 }

--- a/src/compilation/swaypad.rs
+++ b/src/compilation/swaypad.rs
@@ -1,7 +1,6 @@
 use fs_extra::dir::{copy, CopyOptions};
 use nanoid::nanoid;
-use regex::Regex;
-use std::fs::{ remove_dir_all, File, create_dir_all};
+use std::fs::{create_dir_all, remove_dir_all, File};
 use std::io::prelude::*;
 
 const PROJECTS: &str = "projects";

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ mod util;
 use compilation::build_and_destroy_project;
 use cors::Cors;
 use rocket::serde::json::Json;
-use types::{CompileRequest, CompileResponse, TranspileRequest, Language};
+use types::{CompileRequest, CompileResponse, Language, TranspileRequest};
 
-use crate::{types::TranspileResponse, transpilation::solidity_to_sway};
+use crate::{transpilation::solidity_to_sway, types::TranspileResponse};
 
 /// The endpoint to compile a Sway contract.
 #[post("/compile", data = "<request>")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,21 +5,32 @@ extern crate rocket;
 
 mod compilation;
 mod cors;
+mod transpilation;
 mod types;
 mod util;
 
 use compilation::build_and_destroy_project;
 use cors::Cors;
 use rocket::serde::json::Json;
-use types::{CompileRequest, CompileResponse};
+use types::{CompileRequest, CompileResponse, TranspileRequest, Language};
 
-/// The compile endpoint.
+use crate::{types::TranspileResponse, transpilation::solidity_to_sway};
+
+/// The endpoint to compile a Sway contract.
 #[post("/compile", data = "<request>")]
 fn compile(request: Json<CompileRequest>) -> Json<CompileResponse> {
     Json(build_and_destroy_project(
         request.contract.to_string(),
         request.toolchain.to_string(),
     ))
+}
+
+/// The endpoint to transpile a contract written in another language into Sway.
+#[post("/transpile", data = "<request>")]
+fn transpile(request: Json<TranspileRequest>) -> Json<TranspileResponse> {
+    match request.lanaguage {
+        Language::Solidity => Json(solidity_to_sway(request.contract.to_string())),
+    }
 }
 
 /// Catches all OPTION requests in order to get the CORS related Fairing triggered.
@@ -45,6 +56,6 @@ fn health() -> String {
 fn rocket() -> _ {
     rocket::build()
         .attach(Cors)
-        .mount("/", routes![compile, all_options, health])
+        .mount("/", routes![compile, transpile, all_options, health])
         .register("/", catchers![not_found])
 }

--- a/src/transpilation/mod.rs
+++ b/src/transpilation/mod.rs
@@ -1,12 +1,11 @@
 mod solidity;
 
 use self::solidity::run_charcoal;
-use crate::{types::{CompileResponse, TranspileResponse}, util::clean_error_content};
+use crate::{types::TranspileResponse, util::clean_error_content};
 use nanoid::nanoid;
 use regex::Regex;
-use rocket::http::uri::Path;
 use std::{
-    fs::{create_dir_all, remove_file, File, remove_dir_all},
+    fs::{create_dir_all, remove_dir_all, File},
     io::Write,
     path::PathBuf,
 };
@@ -40,7 +39,7 @@ pub fn solidity_to_sway(contract: String) -> TranspileResponse {
                 let re = Regex::new(r"// Translated from.*").unwrap();
                 let replacement = "// Transpiled from Solidity using charcoal. Generated code may be incorrect or unoptimal.";
                 let sway_contract = re.replace_all(result, replacement).into_owned();
-            
+
                 TranspileResponse {
                     sway_contract,
                     error: None,
@@ -48,9 +47,10 @@ pub fn solidity_to_sway(contract: String) -> TranspileResponse {
             } else {
                 TranspileResponse {
                     sway_contract: "".to_string(),
-                    error: Some(format!(
+                    error: Some(
                         "An unknown error occurred while transpiling the Solidity contract."
-                    )),
+                            .to_string(),
+                    ),
                 }
             };
 

--- a/src/transpilation/mod.rs
+++ b/src/transpilation/mod.rs
@@ -1,0 +1,95 @@
+mod solidity;
+
+use self::solidity::run_charcoal;
+use crate::{types::{CompileResponse, TranspileResponse}, util::clean_error_content};
+use nanoid::nanoid;
+use regex::Regex;
+use rocket::http::uri::Path;
+use std::{
+    fs::{create_dir_all, remove_file, File, remove_dir_all},
+    io::Write,
+    path::PathBuf,
+};
+
+const TMP: &str = "tmp";
+const FILE_NAME: &str = "main.sol";
+
+/// Transpile the given Solitiy contract to Sway.
+pub fn solidity_to_sway(contract: String) -> TranspileResponse {
+    if contract.is_empty() {
+        return TranspileResponse {
+            sway_contract: "".to_string(),
+            error: Some("No contract.".to_string()),
+        };
+    }
+
+    match create_project(contract) {
+        Ok(project_name) => {
+            // Run charcoal on the file and capture the output.
+            let output = run_charcoal(contract_path(project_name.clone()));
+            let response = if !output.stderr.is_empty() {
+                let error: &str = std::str::from_utf8(&output.stderr).unwrap();
+                TranspileResponse {
+                    sway_contract: "".to_string(),
+                    error: Some(clean_error_content(error.to_string(), FILE_NAME)),
+                }
+            } else if !output.stdout.is_empty() {
+                let result = std::str::from_utf8(&output.stdout).unwrap();
+
+                // Replace the generated comments from charcoal with a custom comment.
+                let re = Regex::new(r"// Translated from.*").unwrap();
+                let replacement = "// Transpiled from Solidity using charcoal. Generated code may be incorrect or unoptimal.";
+                let sway_contract = re.replace_all(result, replacement).into_owned();
+            
+                TranspileResponse {
+                    sway_contract,
+                    error: None,
+                }
+            } else {
+                TranspileResponse {
+                    sway_contract: "".to_string(),
+                    error: Some(format!(
+                        "An unknown error occurred while transpiling the Solidity contract."
+                    )),
+                }
+            };
+
+            // Delete the temporary file.
+            if let Err(err) = remove_project(project_name.clone()) {
+                return TranspileResponse {
+                    sway_contract: String::from(""),
+                    error: Some(format!("Failed to remove temporary file: {err}")),
+                };
+            }
+
+            response
+        }
+        Err(err) => TranspileResponse {
+            sway_contract: "".to_string(),
+            error: Some(format!("Failed to create temporary file: {err}")),
+        },
+    }
+}
+
+fn create_project(contract: String) -> std::io::Result<String> {
+    // Create a new project file.
+    let project_name = nanoid!();
+    create_dir_all(project_path(project_name.clone()))?;
+    let mut file = File::create(contract_path(project_name.clone()))?;
+
+    // Write the contract to the file.
+    file.write_all(contract.as_bytes())?;
+    Ok(project_name)
+}
+
+fn remove_project(project_name: String) -> std::io::Result<()> {
+    remove_dir_all(project_path(project_name))
+}
+
+fn project_path(project_name: String) -> String {
+    format!("{TMP}/{project_name}")
+}
+
+fn contract_path(project_name: String) -> PathBuf {
+    PathBuf::from(format!("{}/{FILE_NAME}", project_path(project_name)))
+}

--- a/src/transpilation/solidity.rs
+++ b/src/transpilation/solidity.rs
@@ -1,5 +1,8 @@
 use crate::util::spawn_and_wait;
-use std::{path::PathBuf, process::{Command, Output}};
+use std::{
+    path::PathBuf,
+    process::{Command, Output},
+};
 
 const CHARCOAL: &str = "charcoal";
 

--- a/src/transpilation/solidity.rs
+++ b/src/transpilation/solidity.rs
@@ -1,0 +1,13 @@
+use crate::util::spawn_and_wait;
+use std::{path::PathBuf, process::{Command, Output}};
+
+const CHARCOAL: &str = "charcoal";
+
+/// Use forc to build the project.
+pub fn run_charcoal(path: PathBuf) -> Output {
+    spawn_and_wait(
+        Command::new(CHARCOAL)
+            .arg("--target")
+            .arg(path.to_string_lossy().to_string()),
+    )
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,11 @@
 use rocket::serde::{Deserialize, Serialize};
 
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Language {
+    Solidity,
+}
+
 /// The compile request.
 #[derive(Deserialize)]
 pub struct CompileRequest {
@@ -14,6 +20,23 @@ pub struct CompileResponse {
     pub abi: String,
     pub bytecode: String,
     pub storage_slots: String,
-    pub error: String,
     pub forc_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The transpile request.
+#[derive(Deserialize, Debug)]
+pub struct TranspileRequest {
+    pub contract: String,
+    pub lanaguage: Language,
+}
+
+/// The response to a compile request.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranspileResponse {
+    pub sway_contract: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use rocket::serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Language {
     Solidity,
@@ -26,7 +26,7 @@ pub struct CompileResponse {
 }
 
 /// The transpile request.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 pub struct TranspileRequest {
     pub contract: String,
     pub lanaguage: Language,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,8 @@
+use regex::Regex;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
-
-use regex::Regex;
 
 /// Check the version of forc.
 pub fn spawn_and_wait(cmd: &mut Command) -> Output {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,8 @@ use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
+use regex::Regex;
+
 /// Check the version of forc.
 pub fn spawn_and_wait(cmd: &mut Command) -> Output {
     // Pipe stdin, stdout, and stderr to the child.
@@ -40,4 +42,11 @@ pub fn read_file_contents(file_name: String) -> Vec<u8> {
 
     // Return the file's contents.
     file_content
+}
+
+/// This replaces the full file paths in error messages with just the file name.
+pub fn clean_error_content(content: String, filename: &str) -> std::string::String {
+    let path_pattern = Regex::new(format!(r"(/).*(/{filename})").as_str()).unwrap();
+
+    path_pattern.replace_all(&content, filename).to_string()
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-playground/issues/43

Allows users to transpile solidity contracts into Sway and then compile the sway code. Credit to @SilentCicero for the idea!

To test it locally, you'll need to [run the server locally](https://github.com/FuelLabs/sway-playground/blob/master/README.md#running-the-sway-compiler-server) as well as the [frontend](https://github.com/FuelLabs/sway-playground/blob/master/README.md#running-the-frontend), and uncomment the `SERVER_URI` in constants.ts, to point to the local server.

![Mar-15-2024 17-10-21](https://github.com/FuelLabs/sway-playground/assets/47993817/9b7a8b86-843a-455d-bb4e-7d36a2e4b33b)

![Mar-15-2024 17-07-49](https://github.com/FuelLabs/sway-playground/assets/47993817/2b748d69-4f89-4c35-9b69-d0211106ae83)
