### PR TITLE
Emergency patch to fix api.sway-playground to prod-2-api.sway-playgr

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -2,7 +2,7 @@ export const FUEL_GREEN = '#00f58c';
 
 export const SERVER_URI = process.env.REACT_APP_LOCAL_SERVER
   ? 'http://0.0.0.0:8080'
-  : 'https://api.sway-playground.org';
+  : 'https://prod-2-api.sway-playground.org';
 
 export const DEFAULT_SWAY_CONTRACT = `contract;
 


### PR DESCRIPTION
This patch just fixes the api.sway to prod-2-api.sway URL.