### PR TITLE
Change example dropdown selector

### DIFF
--- a/app/src/features/editor/components/ActionOverlay.tsx
+++ b/app/src/features/editor/components/ActionOverlay.tsx
@@ -16,7 +16,7 @@ function ActionOverlay({
   handleSelectExample,
   toolchain,
   setToolchain,
-  editorLanguage
+  editorLanguage,
 }: ActionOverlayProps) {
   return (
     <div style={{ position: 'relative' }}>
@@ -28,17 +28,25 @@ function ActionOverlay({
           zIndex: 1,
           pointerEvents: 'none',
         }}>
-        {(toolchain && setToolchain) && <ToolchainDropdown
+        <div
           style={{
             position: 'absolute',
-            right: '68px',
-            top: '18px',
+            right: '22px',
+            top: '22px',
             pointerEvents: 'all',
-          }}
-          toolchain={toolchain}
-          setToolchain={setToolchain}
-        />}
-        <ExampleDropdown handleSelect={handleSelectExample} examples={EXAMPLE_CONTRACTS[editorLanguage]} />
+          }}>
+          {toolchain && setToolchain && (
+            <ToolchainDropdown
+              style={{ marginRight: '18px' }}
+              toolchain={toolchain}
+              setToolchain={setToolchain}
+            />
+          )}
+          <ExampleDropdown
+            handleSelect={handleSelectExample}
+            examples={EXAMPLE_CONTRACTS[editorLanguage]}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/src/features/editor/components/ExampleDropdown.tsx
+++ b/app/src/features/editor/components/ExampleDropdown.tsx
@@ -5,6 +5,9 @@ import IconButton from '@mui/material/IconButton';
 import FileOpen from '@mui/icons-material/FileOpen';
 import { Dropdown } from '@mui/base/Dropdown/Dropdown';
 import Menu from '@mui/material/Menu/Menu';
+import FormControl from '@mui/material/FormControl/FormControl';
+import Select from '@mui/material/Select/Select';
+import InputLabel from '@mui/material/InputLabel/InputLabel';
 
 export interface ExampleMenuItem {
   label: string;
@@ -22,52 +25,43 @@ function ExampleDropdown({
   examples,
   style,
 }: ExampleDropdownProps) {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [currentExample, setCurrentExample] =
+    React.useState<ExampleMenuItem | null>(null);
 
-  const onButtonClick = useCallback((event: any) => {
-    setAnchorEl(event.target);
-  }, [setAnchorEl]);
-
-  const handleClose = useCallback(() => {
-    setAnchorEl(null);
-  }, [setAnchorEl]);
-
-  const onItemClick = useCallback((code: string) => {
-    handleClose();
-    handleSelect(code);
-  }, [handleSelect, handleClose]);
+  const onChange = useCallback(
+    (event: any) => {
+      const index = event.target.value as number;
+      const example = examples[index];
+      if (example) {
+        setCurrentExample(example);
+        handleSelect(example.code);
+      }
+    },
+    [handleSelect, setCurrentExample]
+  );
 
   return (
-    <div style={{ ...style }}>
-      <Dropdown>
-        <Tooltip placement='top' title={'Select an example'}>
-          <IconButton
-            style={{
-              position: 'absolute',
-              right: '18px',
-              top: '18px',
-              pointerEvents: 'all',
-            }}
-            onClick={onButtonClick}
-            aria-label='select an example'>
-            <FileOpen />
-          </IconButton>
-        </Tooltip>
-
-        <Menu
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={handleClose}>
-          {examples.map(({ label, code }: ExampleMenuItem, index) => (
-            <MenuItem
-              key={`${label}-${index}`}
-              onClick={() => onItemClick(code)}>
-              {label}
-            </MenuItem>
-          ))}
-        </Menu>
-      </Dropdown>
-    </div>
+    <FormControl style={{ ...style }} size='small'>
+      <InputLabel id='example-select-label'>Example</InputLabel>
+      <Tooltip placement='top' title={'Load an example contract'}>
+        <span>
+          <Select
+            id='example-select'
+            labelId='example-select-label'
+            label='Example'
+            variant='outlined'
+            style={{ minWidth: '110px', background: 'white' }}
+            value={currentExample?.label}
+            onChange={onChange}>
+            {examples.map(({ label }: ExampleMenuItem, index) => (
+              <MenuItem key={`${label}-${index}`} value={index}>
+                {label}
+              </MenuItem>
+            ))}
+          </Select>
+        </span>
+      </Tooltip>
+    </FormControl>
   );
 }
 

--- a/app/src/features/editor/components/ExampleDropdown.tsx
+++ b/app/src/features/editor/components/ExampleDropdown.tsx
@@ -33,7 +33,7 @@ function ExampleDropdown({
         handleSelect(example.code);
       }
     },
-    [handleSelect, setCurrentExample]
+    [handleSelect, setCurrentExample, examples]
   );
 
   return (

--- a/app/src/features/editor/components/ExampleDropdown.tsx
+++ b/app/src/features/editor/components/ExampleDropdown.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
-import IconButton from '@mui/material/IconButton';
-import FileOpen from '@mui/icons-material/FileOpen';
-import { Dropdown } from '@mui/base/Dropdown/Dropdown';
-import Menu from '@mui/material/Menu/Menu';
 import FormControl from '@mui/material/FormControl/FormControl';
 import Select from '@mui/material/Select/Select';
 import InputLabel from '@mui/material/InputLabel/InputLabel';

--- a/app/src/features/editor/components/ToolchainDropdown.tsx
+++ b/app/src/features/editor/components/ToolchainDropdown.tsx
@@ -3,6 +3,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel/InputLabel';
 
 const ToolchainNames = [
   'beta-5',
@@ -26,29 +27,27 @@ function ToolchainDropdown({
   style,
 }: ToolchainDropdownProps) {
   return (
-    <div style={{ ...style }}>
-      <FormControl sx={{ minWidth: '70px' }} size='small'>
-        <Tooltip
-          placement='top'
-          title={'The Fuel toolchain to use for compilation'}>
-          <span>
-            <Select
-              sx={{ backgroundColor: 'white', fontSize: '16px' }}
-              variant='outlined'
-              value={toolchain}
-              onChange={(event) =>
-                setToolchain(event.target.value as Toolchain)
-              }>
-              {ToolchainNames.map((toolchain) => (
-                <MenuItem key={toolchain} value={toolchain}>
-                  {toolchain}
-                </MenuItem>
-              ))}
-            </Select>
-          </span>
-        </Tooltip>
-      </FormControl>
-    </div>
+    <FormControl style={{ ...style }} size='small'>
+      <InputLabel id='toolchain-select-label'>Toolchain</InputLabel>
+      <Tooltip placement='top' title={'Fuel toolchain to use for compilation'}>
+        <span>
+          <Select
+            id='toolchain-select'
+            labelId='toolchain-select-label'
+            label='Toolchain'
+            style={{ minWidth: '70px', background: 'white' }}
+            variant='outlined'
+            value={toolchain}
+            onChange={(event) => setToolchain(event.target.value as Toolchain)}>
+            {ToolchainNames.map((toolchain) => (
+              <MenuItem key={toolchain} value={toolchain}>
+                {toolchain}
+              </MenuItem>
+            ))}
+          </Select>
+        </span>
+      </Tooltip>
+    </FormControl>
   );
 }
 

--- a/app/src/features/editor/examples/solidity/counter.ts
+++ b/app/src/features/editor/examples/solidity/counter.ts
@@ -1,5 +1,4 @@
-export const EXAMPLE_SOLIDITY_CONTRACT_COUNTER = `// no support for delegatecall, this, strings & ASM blocks.
-pragma solidity ^0.8.24;
+export const EXAMPLE_SOLIDITY_CONTRACT_COUNTER = `pragma solidity ^0.8.24;
 
 contract Counter {
     uint64 count;

--- a/app/src/features/editor/hooks/useTranspile.tsx
+++ b/app/src/features/editor/hooks/useTranspile.tsx
@@ -20,8 +20,10 @@ export function useTranspile(
       <>
         Transpiling Solidity code with{' '}
         <a href='https://github.com/camden-smallwood/charcoal'>charcoal</a>...
-        <br />
-        WARNING: no support for delegatecall, this, ASM, strings. Coming soon in future releases.
+      </>,
+      <>
+        WARNING: no support for delegatecall, this, ASM, strings. Coming soon in
+        future releases.
       </>,
     ]);
 


### PR DESCRIPTION
Changes the example selector icon to a dropdown with a label.

![image](https://github.com/FuelLabs/sway-playground/assets/47993817/a90d5f00-d47b-4a47-89ec-cd646991e823)

![image](https://github.com/FuelLabs/sway-playground/assets/47993817/ecc747e0-07e5-420a-adb7-db5aac6c837c)

mobile:

<img width="408" alt="image" src="https://github.com/FuelLabs/sway-playground/assets/47993817/43a53b45-fa94-4194-913b-6090201091ab">