### PR TITLE
UI Only show Interact button when deployed

### DIFF
--- a/app/src/features/toolbar/components/ActionToolbar.tsx
+++ b/app/src/features/toolbar/components/ActionToolbar.tsx
@@ -68,12 +68,11 @@ function ActionToolbar({
           updateLog={updateLog}
         />
       )}
-      {!isMobile && (
+      {!isMobile && deployState === DeployState.DEPLOYED && (
         <SecondaryButton
           header={true}
           onClick={() => setDrawerOpen(!drawerOpen)}
           text='INTERACT'
-          disabled={deployState !== DeployState.DEPLOYED}
           tooltip={
             deployState !== DeployState.DEPLOYED
               ? 'A contract must be deployed to interact with it on-chain'


### PR DESCRIPTION
## Description

Only show the `Interact` button when the contract is deployed. This way we can reduce a button on the toolbar. Eventually deploy can be modified to allow for us to enter an address or deploy it.