### PR TITLE
Deserialize toolchain enum rather than string

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use rocket::serde::{Deserialize, Serialize};
+use std::fmt::{self};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -6,11 +7,35 @@ pub enum Language {
     Solidity,
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Toolchain {
+    #[serde(rename = "beta-5")]
+    Beta5,
+    #[serde(rename = "beta-4")]
+    Beta4,
+    #[serde(rename = "beta-3")]
+    Beta3,
+    #[serde(rename = "beta-2")]
+    Beta2,
+    #[serde(rename = "beta-1")]
+    Beta1,
+    Latest,
+    Nightly,
+}
+
+impl fmt::Display for Toolchain {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let se = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        write!(formatter, "{}", se)
+    }
+}
+
 /// The compile request.
 #[derive(Deserialize)]
 pub struct CompileRequest {
     pub contract: String,
-    pub toolchain: String,
+    pub toolchain: Toolchain,
 }
 
 /// The response to a compile request.


### PR DESCRIPTION
This ensures only valid toolchains are run in the command line.