### PR TITLE
Enable PRs from external forks to pass CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          push: true
+          push: github.ref == 'refs/heads/master'
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
           push: true
           tags: ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
 
+      - uses: actions/checkout@v2
       - name: NPM build
-        uses: actions/checkout@v2      
         env:
           CI: true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          push: github.ref == 'refs/heads/master'
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
       LOCAL_REGISTRY: localhost:5000
       LOCAL_TAG: sway-playground:local
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -159,7 +162,6 @@ jobs:
           push: true
           tags: ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
 
-      - uses: actions/checkout@v2
       - name: NPM build
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo '${{ toJSON(steps.meta.outputs) }}' 
-      - run: docker images
-
       - name: Build and push the image to ghcr.io
         uses: docker/build-push-action@v2
         with:
@@ -129,6 +126,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - run: echo '${{ toJSON(steps.meta.outputs) }}' 
+      - run: docker images          
 
   frontend-build-and-test:
     if: github.ref != 'refs/heads/master'
@@ -142,6 +142,7 @@ jobs:
           CI: true
         run: |
           cd app && npm ci && npm run build
+      - run: docker images
       - name: Run the service in docker
         run: |
           docker run -d -p 8080:8080 ${{ needs.build-and-publish-image.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,13 @@ jobs:
           args: --verbose --all --all-features
 
   build-and-publish-image:
+    if: github.ref == 'refs/heads/master'
     needs:
       - cargo-fmt-check
       - cargo-clippy
       - cargo-check
       - cargo-test
     runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -121,31 +120,55 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          push: ${{ github.ref == 'refs/heads/master' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - run: echo '${{ toJSON(steps.meta.outputs) }}' 
-      - run: docker images          
-
   frontend-build-and-test:
     if: github.ref != 'refs/heads/master'
-    needs:
-      - build-and-publish-image
     runs-on: ubuntu-latest
+    # Local docker image registry
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    env:
+      LOCAL_REGISTRY: localhost:5000
+      LOCAL_TAG: sway-playground:local
     steps:
-      - uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+
+      - name: Log in to the local registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.LOCAL_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image and push to local registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: deployment/Dockerfile
+          push: true
+          tags: ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
+
       - name: NPM build
+        uses: actions/checkout@v2      
         env:
           CI: true
         run: |
           cd app && npm ci && npm run build
-      - run: docker images
+
       - name: Run the service in docker
         run: |
-          docker run -d -p 8080:8080 ${{ needs.build-and-publish-image.outputs.tags }}
+          docker run -d -p 8080:8080 ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
       - name: NPM test
         run: |
           cd app && npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: echo '${{ toJSON(steps.meta.outputs) }}' 
+      - run: docker images
+
       - name: Build and push the image to ghcr.io
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
 
   frontend-build-and-test:
     if: github.ref != 'refs/heads/master'
+    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     # Local docker image registry
     services:
@@ -162,18 +163,18 @@ jobs:
           push: true
           tags: ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
 
-      - name: NPM build
-        env:
-          CI: true
-        run: |
-          cd app && npm ci && npm run build
-
       - name: Run the service in docker
         run: |
           docker run -d -p 8080:8080 ${{ env.LOCAL_REGISTRY }}/${{ env.LOCAL_TAG }}
-      - name: NPM test
+
+      - name: NPM build and test
+        env:
+          CI: true
         run: |
-          cd app && npm run test
+          cd app
+          npm ci
+          npm run build
+          npm run test
 
   deploy:
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
External contributors do not have permission to push to ghcr. To allow external PRs to run all of the workflows, we should only push to ghcr when necessary.

Example: https://github.com/FuelLabs/sway-playground/pull/59

This PR changes the workflow so that we only push to ghcr on merges to master. On PRs, we build the docker image and push to a local registry that can be used in a later step.