### PR TITLE
Fix deploy metrics

### DIFF
--- a/app/src/features/toolbar/hooks/useDeployContract.ts
+++ b/app/src/features/toolbar/hooks/useDeployContract.ts
@@ -1,6 +1,9 @@
 import { ContractFactory, JsonAbi, StorageSlot } from 'fuels';
 import { useMutation } from '@tanstack/react-query';
 import { useFuel, useWallet } from '@fuels/react';
+import { track } from '@vercel/analytics/react';
+import { useEffect, useState } from 'react';
+import { toMetricProperties } from '../../../utils/metrics';
 
 const DEPLOYMENT_TIMEOUT_MS = 120000;
 
@@ -19,19 +22,35 @@ export function useDeployContract(
 ) {
   const { wallet, isLoading: walletIsLoading } = useWallet();
   const { fuel } = useFuel();
+  const [metricMetadata, setMetricMetadata] = useState({});
+
+  useEffect(() => {
+    const waitForMetadata = async () => {
+      const name = fuel.currentConnector()?.name ?? 'none';
+      const networkUrl = wallet?.provider.url ?? 'none';
+      const version = (await wallet?.provider.getVersion()) ?? 'none';
+      setMetricMetadata({ name, version, networkUrl });
+    };
+    waitForMetadata();
+  }, [wallet, fuel]);
 
   const mutation = useMutation({
     // Retry once if the wallet is still loading.
     retry: walletIsLoading && !wallet ? 1 : 0,
-    onSuccess: onSuccess,
-    onError: onError,
+    onSuccess,
+    onError: (error) => {
+      console.error(`Deployment failed: ${error.message}`);
+      track('Deploy Error', toMetricProperties(error, metricMetadata));
+      onError(error);
+    },
     mutationFn: async () => {
-      const network = await fuel.currentNetwork();
       if (!wallet) {
         if (walletIsLoading) {
           updateLog('Connecting to wallet...');
         } else {
-          throw new Error('Failed to connect to wallet');
+          throw new Error('Failed to connect to wallet', {
+            cause: { source: 'wallet' },
+          });
         }
       }
 
@@ -49,26 +68,27 @@ export function useDeployContract(
             });
             resolve({
               contractId: contract.id.toB256(),
-              networkUrl: network.url,
+              networkUrl: contract.provider.url,
             });
           } catch (error) {
-            reject(error);
+            reject(
+              new Error(`SDK Error: ${JSON.stringify(error)}`, {
+                cause: { source: 'sdk' },
+              })
+            );
           }
         }
       );
 
       const timeoutPromise = new Promise((_resolve, reject) =>
-        setTimeout(
-          () =>
-            reject(
-              new Error(
-                `Request timed out after ${
-                  DEPLOYMENT_TIMEOUT_MS / 1000
-                } seconds`
-              )
-            ),
-          DEPLOYMENT_TIMEOUT_MS
-        )
+        setTimeout(() => {
+          reject(
+            new Error(
+              `Request timed out after ${DEPLOYMENT_TIMEOUT_MS / 1000} seconds`,
+              { cause: { source: 'timeout' } }
+            )
+          );
+        }, DEPLOYMENT_TIMEOUT_MS)
       );
 
       return await Promise.race([resultPromise, timeoutPromise]);

--- a/app/src/utils/metrics.test.ts
+++ b/app/src/utils/metrics.test.ts
@@ -1,0 +1,15 @@
+import { toMetricProperties } from './metrics';
+
+describe(`test toMetricProperties`, () => {
+  test.each`
+    label                          | cause                 | metadata              | expected
+    ${'with metadata and cause'}   | ${{ source: 'test' }} | ${{ other: 'other' }} | ${{ source: 'test', other: 'other' }}
+    ${'with invalid cause'}        | ${'str'}              | ${undefined}          | ${undefined}
+    ${'without cause or metadata'} | ${undefined}          | ${undefined}          | ${undefined}
+    ${'with cause only'}           | ${{ source: 'test' }} | ${undefined}          | ${{ source: 'test' }}
+    ${'with metadata only'}        | ${undefined}          | ${{ other: 'other' }} | ${{ other: 'other' }}
+  `('$label', ({ cause, metadata, expected }) => {
+    const error = cause ? new Error('Test', { cause }) : new Error('Test');
+    expect(toMetricProperties(error, metadata)).toEqual(expected);
+  });
+});

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -7,7 +7,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isAllowedEntry(
   entry: [string, unknown]
 ): entry is [string, AllowedProperty] {
-  const [_, value] = entry;
+  const value = entry[1];
   return (
     typeof value === 'string' ||
     typeof value === 'number' ||

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -7,7 +7,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isAllowedEntry(
   entry: [string, unknown]
 ): entry is [string, AllowedProperty] {
-  const [_key, value] = entry;
+  const [_, value] = entry;
   return (
     typeof value === 'string' ||
     typeof value === 'number' ||

--- a/app/src/utils/metrics.ts
+++ b/app/src/utils/metrics.ts
@@ -1,0 +1,36 @@
+type AllowedProperty = string | number | boolean | null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isAllowedEntry(
+  entry: [string, unknown]
+): entry is [string, AllowedProperty] {
+  const [_key, value] = entry;
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  );
+}
+
+export function toMetricProperties(
+  error: Error,
+  metadata?: Record<string, unknown>
+): Record<string, AllowedProperty> | undefined {
+  const combined = { ...metadata };
+  if (isRecord(error.cause)) {
+    Object.assign(combined, error.cause);
+  }
+  if (!!Object.keys(combined).length) {
+    return Object.entries(combined)
+      .filter(isAllowedEntry)
+      .reduce((acc: Record<string, AllowedProperty>, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {});
+  }
+  return undefined;
+}


### PR DESCRIPTION
- splits up the "user canceled transaction" type errors from the other sdk errors. I suspect that is the majority of deployment errors.
- fixes an issue where deployment errors were tracked twice
- adds the wallet version to the deployment error event
- adds an error log when deployment fails