### PR TITLE
feat: allow sway playground to be opened from docs hub

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { Toolchain } from './features/editor/components/ToolchainDropdown';
 import { useTranspile } from './features/editor/hooks/useTranspile';
 import EditorView from './features/editor/components/EditorView';
 import { Analytics, track } from '@vercel/analytics/react';
+import { APPROVED_EXTERNAL_DOMAIN } from './constants';
 
 const DRAWER_WIDTH = '40vw';
 
@@ -55,6 +56,28 @@ function App() {
 
   // An error message to display to the user.
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    function setLocalStorageFromExternalDomain(message: MessageEvent) {
+      if (message.origin !== APPROVED_EXTERNAL_DOMAIN) {
+        return;
+      }
+
+      const data = JSON.parse(message.data);
+      const { swayCode } = data;
+      // I'm only expecting us to set sway code from the docs hub.
+      // If users want to see the corresponding solidity they can use the built-in transpiler.
+      if (swayCode) {
+        onSwayCodeChange(swayCode);
+      }
+    }
+
+    window.addEventListener('message', setLocalStorageFromExternalDomain);
+
+    return () => {
+      window.removeEventListener('message', setLocalStorageFromExternalDomain);
+    };
+  }, []);
 
   useEffect(() => {
     if (showSolidity) {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
     return () => {
       window.removeEventListener('message', setLocalStorageFromExternalDomain);
     };
-  }, []);
+  });
 
   useEffect(() => {
     if (showSolidity) {

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,6 +1,10 @@
 export const FUEL_GREEN = '#00f58c';
 
 export const LOCAL_SERVER_URI = 'http://0.0.0.0:8080';
-export const SERVER_URI = process.env.REACT_APP_LOCAL_SERVER
+export const IS_LOCAL = !!process.env.REACT_APP_LOCAL_SERVER;
+export const SERVER_URI = IS_LOCAL
   ? LOCAL_SERVER_URI
   : 'https://api.sway-playground.org';
+export const APPROVED_EXTERNAL_DOMAIN = IS_LOCAL
+  ? 'http://localhost:3000' // Local domain of docs hub
+  : 'https://docs-hub.vercel.app';


### PR DESCRIPTION
We have begun the process of integrating sway playground into the docs hub.  To start we simply added a button below full code examples to open the examples in sway playground.  For this to be possible this modification to sway-playground is required.  Let me know if there is a better way to implement this functionality.

To test this locally, run sway-playground locally, checkout the corresponding docs hub and run that locally as well.  You may need to run git submodule update --init --recursive.

corresponding docs hub pr https://github.com/FuelLabs/docs-hub/pull/243