### PR TITLE
feat: Sharable permanent links using gists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +62,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +100,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -75,7 +111,7 @@ checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -105,6 +141,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +168,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +190,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -151,15 +220,28 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "cipher"
@@ -188,6 +270,22 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -244,18 +342,18 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -307,6 +405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +427,7 @@ checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -343,10 +451,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "futures-sink"
@@ -369,6 +499,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -402,13 +533,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -420,6 +553,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -438,7 +577,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.8",
  "indexmap",
  "slab",
  "tokio",
@@ -451,6 +590,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -497,13 +642,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.8",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -530,17 +709,121 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.8",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.7",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -579,6 +862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +887,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,9 +909,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "lock_api"
@@ -661,15 +969,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mio"
-version = "0.8.5"
+name = "miniz_oxide"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -681,12 +997,12 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.8",
  "httparse",
  "log",
  "memchr",
  "mime",
- "spin 0.9.4",
+ "spin 0.9.8",
  "tokio",
  "tokio-util",
  "version_check",
@@ -712,6 +1028,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +1063,54 @@ checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a8a3df00728324ad654ecd1ed449a60157c55b7ff8c109af3a35989687c367"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -732,6 +1124,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "overload"
@@ -759,7 +1157,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -782,7 +1180,17 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -792,10 +1200,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
+name = "pin-project"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -823,9 +1251,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -838,16 +1266,16 @@ checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -888,7 +1316,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -908,7 +1336,7 @@ checksum = "9f9c0c92af03644e4806106281fe2e068ac5bc0ae74a707266d06ea27bccee5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -956,9 +1384,24 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1012,7 +1455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -1025,8 +1468,8 @@ dependencies = [
  "cookie",
  "either",
  "futures",
- "http",
- "hyper",
+ "http 0.2.8",
+ "hyper 0.14.23",
  "indexmap",
  "log",
  "memchr",
@@ -1034,17 +1477,23 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ref-cast",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.20.7",
+ "rustls-pemfile 1.0.1",
  "serde",
  "smallvec",
  "stable-pattern",
  "state",
  "time",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "uncased",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustls"
@@ -1053,9 +1502,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1065,6 +1541,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1078,6 +1581,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1097,28 +1609,60 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1127,6 +1671,28 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1162,6 +1728,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,9 +1750,30 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75976f4748ab44f6e5332102be424e7c2dc18daeaf7e725f2040c3ebb133512e"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b19911debfb8c2fb1107bc6cb2d61868aaf53a988449213959bb1b5b1ed95f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
 
 [[package]]
 name = "socket2"
@@ -1187,6 +1786,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,9 +1803,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable-pattern"
@@ -1218,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "sway-playground"
@@ -1229,10 +1838,12 @@ dependencies = [
  "fs_extra",
  "hex",
  "nanoid",
+ "octocrab",
  "regex",
  "rocket",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1241,6 +1852,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1259,6 +1881,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1298,34 +1940,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.23.0"
+name = "tinyvec"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
- "autocfg",
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1334,9 +1990,20 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.7",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -1374,6 +2041,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1399,7 +2110,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1473,10 +2184,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1486,9 +2212,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -1499,6 +2225,24 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -1549,7 +2293,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1571,7 +2315,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1598,8 +2342,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1638,18 +2382,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1657,6 +2459,18 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1671,6 +2485,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +2507,24 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1695,6 +2539,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,10 +2563,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1725,7 +2605,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
 name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ serde_json = "1.0.91"
 regex = "1.7.0"
 rocket = { version = "0.5.0-rc.2", features = ["tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
+octocrab = "0.38.0"
+thiserror = "1.0.60"

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^18.2.0",
         "react-ace": "^10.1.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -5056,6 +5057,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
+      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -17737,6 +17746,36 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
+      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "dependencies": {
+        "@remix-run/router": "1.16.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
+      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "dependencies": {
+        "@remix-run/router": "1.16.0",
+        "react-router": "6.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -24966,6 +25005,11 @@
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
+      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -34010,6 +34054,23 @@
       "requires": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
+      }
+    },
+    "react-router": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
+      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "requires": {
+        "@remix-run/router": "1.16.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
+      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "requires": {
+        "@remix-run/router": "1.16.0",
+        "react-router": "6.23.0"
       }
     },
     "react-scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/app/src/components/Copyable.tsx
+++ b/app/src/components/Copyable.tsx
@@ -8,20 +8,21 @@ export interface CopyableProps {
   value: string;
   label: string;
   tooltip: string;
+  href?: boolean;
 }
 
 async function handleCopy(value: string) {
   await navigator.clipboard.writeText(value);
 }
 
-function Copyable({ value, label, tooltip }: CopyableProps) {
+function Copyable({ value, label, tooltip, href }: CopyableProps) {
   return (
     <div
       style={{ cursor: 'pointer', color: darkColors.gray6 }}
       onClick={() => handleCopy(value)}>
       <Tooltip title={`Click to copy ${tooltip}`}>
         <span>
-          <span style={{ padding: '8px 0 8px' }}>{label}</span>
+          {href ? (<a href={value} target='_blank' rel='noreferrer'>{label}</a>) : (<span style={{ padding: '8px 0 8px' }}>{label}</span>)}
           <IconButton disableRipple aria-label='copy'>
             <ContentCopyIcon style={{ fontSize: '14px' }} />
           </IconButton>

--- a/app/src/components/Providers.tsx
+++ b/app/src/components/Providers.tsx
@@ -5,6 +5,7 @@ import { queryClient } from '../utils/queryClient';
 import { FuelProvider } from '@fuels/react';
 import { defaultConnectors } from '@fuels/connectors';
 
+
 type ProvidersProps = {
   children: ReactNode;
 };

--- a/app/src/components/SecondaryButton.tsx
+++ b/app/src/components/SecondaryButton.tsx
@@ -24,7 +24,7 @@ function SecondaryButton({
   if (!!header) {
     style = {
       ...style,
-      minWidth: '115px',
+      minWidth: '105px',
       height: '40px',
       marginRight: '15px',
       marginBottom: '10px',

--- a/app/src/features/editor/components/ToolchainDropdown.tsx
+++ b/app/src/features/editor/components/ToolchainDropdown.tsx
@@ -16,6 +16,11 @@ const ToolchainNames = [
 ] as const;
 export type Toolchain = (typeof ToolchainNames)[number];
 
+export function isToolchain(value: string | null): value is Toolchain {
+  const found = ToolchainNames.find(name => name === value);
+  return !!value && found !== undefined;
+}
+
 export interface ToolchainDropdownProps {
   toolchain: Toolchain;
   setToolchain: (toolchain: Toolchain) => void;

--- a/app/src/features/editor/examples/examples.test.ts
+++ b/app/src/features/editor/examples/examples.test.ts
@@ -17,7 +17,7 @@ describe(`test examples`, () => {
         method: 'POST',
         body: JSON.stringify({
           contract: code,
-          lanaguage: 'solidity',
+          language: 'solidity',
         }),
       });
 

--- a/app/src/features/editor/hooks/useGist.tsx
+++ b/app/src/features/editor/hooks/useGist.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { SERVER_URI } from '../../../constants';
 import { track } from '@vercel/analytics/react';
 import { EditorLanguage } from '../components/ActionOverlay';

--- a/app/src/features/editor/hooks/useGist.tsx
+++ b/app/src/features/editor/hooks/useGist.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { SERVER_URI } from '../../../constants';
+import { track } from '@vercel/analytics/react';
+import { EditorLanguage } from '../components/ActionOverlay';
+import { useSearchParams } from 'react-router-dom';
+
+interface GistMeta {
+  url: string;
+  id: string;
+}
+
+interface ContractCode {
+  contract: string;
+  language: EditorLanguage;
+}
+
+interface GistResponse {
+  gist: GistMeta;
+  swayContract: string;
+  transpileContract: ContractCode;
+  error?: string;
+}
+
+export function useGist(
+  onSwayCodeChange: (swayCode: string) => void,
+  onSolidityCodeChange: (solidityCode: string) => void
+): {
+  newGist: (
+    swayContract: string,
+    transpileContract: ContractCode
+  ) => Promise<GistMeta | undefined>;
+} {
+  // The search parameters for the current URL.
+  const [searchParams] = useSearchParams();
+  const [gist, setGist] = useState<GistResponse | null>(null);
+
+  useEffect(() => {
+    const gist_id = searchParams.get('gist');
+    if (!!gist_id) {
+      const request = new Request(`${SERVER_URI}/gist/${gist_id}`, {
+        method: 'GET',
+      });
+
+      fetch(request)
+        .then((response) => {
+          if (response.status < 400) {
+            return response.json();
+          } else {
+            track('Get Gist Error', {
+              source: 'network',
+              status: response.status,
+            });
+          }
+        })
+        .then((response: GistResponse) => {
+          const { error } = response;
+          if (error) {
+            track('Get Gist Error', { source: 'server' });
+          } else {
+            setGist(response);
+          }
+        })
+        .catch(() => {
+          track('Get Gist Error', { source: 'network' });
+        });
+    }
+  }, [searchParams, setGist]);
+
+  // Update the editor code when the gist is loaded.
+  useEffect(() => {
+    if (!!gist) {
+      onSwayCodeChange(gist.swayContract);
+      onSolidityCodeChange(gist.transpileContract.contract);
+    }
+  }, [gist, onSwayCodeChange, onSolidityCodeChange]);
+
+  const newGist = useCallback(
+    async (sway_contract: string, transpile_contract: ContractCode) => {
+      const request = new Request(`${SERVER_URI}/gist`, {
+        method: 'POST',
+        body: JSON.stringify({
+          sway_contract,
+          transpile_contract,
+        }),
+      });
+
+      const res = await fetch(request)
+        .then((response) => {
+          if (response.status < 400) {
+            return response.json();
+          } else {
+            track('New Gist Error', {
+              source: 'network',
+              status: response.status,
+            });
+          }
+        })
+        .then((response: { gist: GistMeta; error: string | undefined }) => {
+          const { error, gist } = response;
+          if (error) {
+            track('New Gist Error', { source: 'server' });
+          } else {
+            return gist;
+          }
+        })
+        .catch(() => {
+          track('New Gist Error', { source: 'network' });
+        });
+
+      return res ?? undefined;
+    },
+    []
+  );
+
+  return { newGist };
+}

--- a/app/src/features/editor/hooks/useLog.tsx
+++ b/app/src/features/editor/hooks/useLog.tsx
@@ -4,7 +4,7 @@ import { darkColors } from '@fuel-ui/css';
 
 const RESULT_LINE_LIMIT = 500;
 
-export function useLog() {
+export function useLog(): [React.ReactElement[], (entry?: string | React.ReactElement[]) => void] {
   // The complete results to show in the compilation output section.
   const [results, setResults] = useState<React.ReactElement[]>([]);
 
@@ -44,5 +44,5 @@ export function useLog() {
     }
   }, [results, resultsToAdd, resultsToAddRef, setResults]);
 
-  return [results, updateLog] as const;
+  return [results, updateLog] ;
 }

--- a/app/src/features/editor/hooks/useTranspile.tsx
+++ b/app/src/features/editor/hooks/useTranspile.tsx
@@ -32,7 +32,7 @@ export function useTranspile(
       method: 'POST',
       body: JSON.stringify({
         contract: code,
-        lanaguage: 'solidity',
+        language: 'solidity',
       }),
     });
 

--- a/app/src/features/toolbar/components/ActionToolbar.tsx
+++ b/app/src/features/toolbar/components/ActionToolbar.tsx
@@ -15,6 +15,7 @@ import { useIsMobile } from '../../../hooks/useIsMobile';
 export interface ActionToolbarProps {
   deployState: DeployState;
   setContractId: (contractId: string) => void;
+  onShareClick: () => void;
   onCompile: () => void;
   isCompiled: boolean;
   setDeployState: (state: DeployState) => void;
@@ -28,6 +29,7 @@ export interface ActionToolbarProps {
 function ActionToolbar({
   deployState,
   setContractId,
+  onShareClick,
   onCompile,
   isCompiled,
   setDeployState,
@@ -38,6 +40,7 @@ function ActionToolbar({
   updateLog,
 }: ActionToolbarProps) {
   const isMobile = useIsMobile();
+
   const onDocsClick = useCallback(() => {
     window.open('https://docs.fuel.network/docs/sway', '_blank', 'noreferrer');
   }, []);
@@ -96,6 +99,12 @@ function ActionToolbar({
         text='DOCS'
         tooltip={'Open documentation for Sway in a new tab'}
         endIcon={<OpenInNew style={{ fontSize: '16px' }} />}
+      />
+      <SecondaryButton
+        header={true}
+        onClick={onShareClick}
+        text='SHARE'
+        tooltip={'Get a shareable link to your code'}
       />
     </div>
   );

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -4,14 +4,23 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import './index.css';
 import { Providers } from './components/Providers';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+  },
+]);
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
+
 root.render(
   <React.StrictMode>
     <Providers>
-      <App />
+      <RouterProvider router={router} />
     </Providers>
   </React.StrictMode>
 );

--- a/src/compilation/mod.rs
+++ b/src/compilation/mod.rs
@@ -6,6 +6,7 @@ use self::{
     tooling::{build_project, check_forc_version, switch_fuel_toolchain},
 };
 use crate::{
+    error::ApiError,
     types::CompileResponse,
     util::{clean_error_content, read_file_contents},
 };
@@ -15,16 +16,19 @@ use std::fs::read_to_string;
 const FILE_NAME: &str = "main.sw";
 
 /// Build and destroy a project.
-pub fn build_and_destroy_project(contract: String, toolchain: String) -> CompileResponse {
+pub fn build_and_destroy_project(
+    contract: String,
+    toolchain: String,
+) -> Result<CompileResponse, ApiError> {
     // Check if any contract has been submitted.
     if contract.is_empty() {
-        return CompileResponse {
+        return Ok(CompileResponse {
             abi: "".to_string(),
             bytecode: "".to_string(),
             storage_slots: "".to_string(),
             forc_version: "".to_string(),
             error: Some("No contract.".to_string()),
-        };
+        });
     }
 
     // Switch to the given fuel toolchain and check forc version.
@@ -32,10 +36,12 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
     let forc_version = check_forc_version();
 
     // Create a new project.
-    let project_name = create_project().unwrap();
+    let project_name =
+        create_project().map_err(|_| ApiError::Filesystem("create project".into()))?;
 
     // Write the file to the temporary project and compile.
-    write_main_file(project_name.to_owned(), contract.as_bytes()).unwrap();
+    write_main_file(project_name.to_owned(), contract.as_bytes())
+        .map_err(|_| ApiError::Filesystem("write main file".into()))?;
     let output = build_project(project_name.clone());
 
     // If the project compiled successfully, read the ABI and BIN files.
@@ -52,16 +58,16 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
         ));
 
         // Remove the project directory and contents.
-        remove_project(project_name).unwrap();
+        remove_project(project_name).map_err(|_| ApiError::Filesystem("remove project".into()))?;
 
         // Return the abi, bin, empty error message, and forc version.
-        CompileResponse {
+        Ok(CompileResponse {
             abi: clean_error_content(abi, FILE_NAME),
             bytecode: clean_error_content(encode(bin), FILE_NAME),
             storage_slots: String::from_utf8_lossy(&storage_slots).into(),
             forc_version,
             error: None,
-        }
+        })
     } else {
         // Get the error message presented in the console output.
         let error = std::str::from_utf8(&output.stderr).unwrap();
@@ -76,12 +82,12 @@ pub fn build_and_destroy_project(contract: String, toolchain: String) -> Compile
         remove_project(project_name).unwrap();
 
         // Return an empty abi, bin, error message, and forc version.
-        CompileResponse {
+        Ok(CompileResponse {
             abi: String::from(""),
             bytecode: String::from(""),
             storage_slots: String::from(""),
             error: Some(clean_error_content(trunc, FILE_NAME)),
             forc_version,
-        }
+        })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+use rocket::{
+    http::Status,
+    response::Responder,
+    serde::{json::Json, Serialize},
+    Request,
+};
+use thiserror::Error;
+
+/// A wrapper for API responses that can return errors.
+pub type ApiResult<T> = Result<Json<T>, ApiError>;
+
+/// An empty response.
+#[derive(Serialize)]
+pub struct EmptyResponse;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("Filesystem error: {0}")]
+    Filesystem(String),
+    #[error("Charcoal error: {0}")]
+    Charcoal(String),
+    #[error("GitHub error: {0}")]
+    Github(String),
+}
+
+impl<'r, 'o: 'r> Responder<'r, 'o> for ApiError {
+    fn respond_to(self, _request: &'r Request<'_>) -> rocket::response::Result<'o> {
+        match self {
+            ApiError::Filesystem(_) => Err(Status::InternalServerError),
+            ApiError::Charcoal(_) => Err(Status::InternalServerError),
+            ApiError::Github(_) => Err(Status::InternalServerError),
+        }
+    }
+}

--- a/src/gist.rs
+++ b/src/gist.rs
@@ -1,0 +1,79 @@
+use octocrab::{models::gists::Gist, Octocrab};
+
+use crate::{
+    error::ApiError,
+    types::{ContractCode, GistMeta, GistResponse, Language, NewGistRequest},
+};
+
+const GIST_SWAY_FILENAME: &str = "playground.sw";
+const GIST_SOLIDITY_FILENAME: &str = "playground.sol";
+
+pub struct GistClient {
+    octocrab: Octocrab,
+}
+
+impl GistClient {
+    pub fn default() -> Self {
+        let gh_token = std::env::var("GITHUB_API_TOKEN").expect("GITHUB_API_TOKEN must be set");
+        let octocrab = Octocrab::builder()
+            .personal_token(gh_token)
+            .build()
+            .expect("octocrab builder");
+        Self { octocrab }
+    }
+
+    /// Creates a new gist.
+    pub async fn create(&self, request: NewGistRequest) -> Result<GistMeta, ApiError> {
+        let gist = self
+            .octocrab
+            .gists()
+            .create()
+            .file(GIST_SWAY_FILENAME, request.sway_contract.clone())
+            .file(
+                GIST_SOLIDITY_FILENAME,
+                request.transpile_contract.contract.clone(),
+            )
+            .send()
+            .await
+            .map_err(|_| ApiError::Github("create gist".into()))?;
+
+        Ok(GistMeta {
+            id: gist.id,
+            url: gist.html_url.to_string(),
+        })
+    }
+
+    /// Fetches a gist by ID.
+    pub async fn get(&self, id: String) -> Result<GistResponse, ApiError> {
+        let gist = self
+            .octocrab
+            .gists()
+            .get(id)
+            .await
+            .map_err(|_| ApiError::Github("get gist".into()))?;
+
+        let sway_contract = Self::extract_file_contents(&gist, GIST_SWAY_FILENAME);
+        let solidity_contract = Self::extract_file_contents(&gist, GIST_SOLIDITY_FILENAME);
+
+        Ok(GistResponse {
+            gist: GistMeta {
+                id: gist.id,
+                url: gist.html_url.to_string(),
+            },
+            sway_contract,
+            transpile_contract: ContractCode {
+                contract: solidity_contract,
+                language: Language::Solidity,
+            },
+            error: None,
+        })
+    }
+
+    fn extract_file_contents(gist: &Gist, filename: &str) -> String {
+        gist.files
+            .get(filename)
+            .map(|file| file.content.clone())
+            .unwrap_or_default()
+            .unwrap_or_default()
+    }
+}

--- a/src/gist.rs
+++ b/src/gist.rs
@@ -14,7 +14,9 @@ pub struct GistClient {
 
 impl GistClient {
     pub fn default() -> Self {
-        let gh_token = std::env::var("GITHUB_API_TOKEN").expect("GITHUB_API_TOKEN must be set");
+        // Do not throw an error if the token is not set. It is only needed in production and for testing
+        // the "Share" feature.
+        let gh_token = std::env::var("GITHUB_API_TOKEN").unwrap_or_default();
         let octocrab = Octocrab::builder()
             .personal_token(gh_token)
             .build()

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,44 +5,62 @@ extern crate rocket;
 
 mod compilation;
 mod cors;
+mod error;
+mod gist;
 mod transpilation;
 mod types;
 mod util;
 
-use compilation::build_and_destroy_project;
-use cors::Cors;
-use rocket::serde::json::Json;
-use types::{CompileRequest, CompileResponse, Language, TranspileRequest};
-
+use crate::compilation::build_and_destroy_project;
+use crate::cors::Cors;
+use crate::error::ApiResult;
+use crate::gist::GistClient;
+use crate::types::{
+    CompileRequest, CompileResponse, GistResponse, Language, NewGistRequest, NewGistResponse,
+    TranspileRequest,
+};
 use crate::{transpilation::solidity_to_sway, types::TranspileResponse};
+use rocket::serde::json::Json;
+use rocket::State;
 
 /// The endpoint to compile a Sway contract.
 #[post("/compile", data = "<request>")]
-fn compile(request: Json<CompileRequest>) -> Json<CompileResponse> {
-    Json(build_and_destroy_project(
-        request.contract.to_string(),
-        request.toolchain.to_string(),
-    ))
+fn compile(request: Json<CompileRequest>) -> ApiResult<CompileResponse> {
+    let response =
+        build_and_destroy_project(request.contract.to_string(), request.toolchain.to_string())?;
+    Ok(Json(response))
 }
 
 /// The endpoint to transpile a contract written in another language into Sway.
 #[post("/transpile", data = "<request>")]
-fn transpile(request: Json<TranspileRequest>) -> Json<TranspileResponse> {
-    match request.lanaguage {
-        Language::Solidity => Json(solidity_to_sway(request.contract.to_string())),
-    }
+fn transpile(request: Json<TranspileRequest>) -> ApiResult<TranspileResponse> {
+    let response = match request.contract_code.language {
+        Language::Solidity => solidity_to_sway(request.contract_code.contract.to_string()),
+    }?;
+    Ok(Json(response))
+}
+
+/// The endpoint to create a new gist to store the playground editors' code.
+#[post("/gist", data = "<request>")]
+async fn new_gist(
+    request: Json<NewGistRequest>,
+    gist: &State<GistClient>,
+) -> ApiResult<NewGistResponse> {
+    let gist = gist.create(request.into_inner()).await?;
+    Ok(Json(NewGistResponse { gist, error: None }))
+}
+
+/// The endpoint to fetch a gist.
+#[get("/gist/<id>")]
+async fn get_gist(id: String, gist: &State<GistClient>) -> ApiResult<GistResponse> {
+    let gist_response = gist.get(id).await?;
+    Ok(Json(gist_response))
 }
 
 /// Catches all OPTION requests in order to get the CORS related Fairing triggered.
 #[options("/<_..>")]
 fn all_options() {
     // Intentionally left empty
-}
-
-/// Catch 404 not founds.
-#[catch(404)]
-fn not_found() -> String {
-    "Not found".to_string()
 }
 
 // Indicates the service is running
@@ -55,7 +73,10 @@ fn health() -> String {
 #[launch]
 fn rocket() -> _ {
     rocket::build()
+        .manage(GistClient::default())
         .attach(Cors)
-        .mount("/", routes![compile, transpile, all_options, health])
-        .register("/", catchers![not_found])
+        .mount(
+            "/",
+            routes![compile, transpile, new_gist, get_gist, all_options, health],
+        )
 }

--- a/src/transpilation/mod.rs
+++ b/src/transpilation/mod.rs
@@ -1,7 +1,7 @@
 mod solidity;
 
 use self::solidity::run_charcoal;
-use crate::{types::TranspileResponse, util::clean_error_content};
+use crate::{error::ApiError, types::TranspileResponse, util::clean_error_content};
 use nanoid::nanoid;
 use regex::Regex;
 use std::{
@@ -14,61 +14,58 @@ const TMP: &str = "tmp";
 const FILE_NAME: &str = "main.sol";
 
 /// Transpile the given Solitiy contract to Sway.
-pub fn solidity_to_sway(contract: String) -> TranspileResponse {
+pub fn solidity_to_sway(contract: String) -> Result<TranspileResponse, ApiError> {
     if contract.is_empty() {
-        return TranspileResponse {
+        return Ok(TranspileResponse {
             sway_contract: "".to_string(),
             error: Some("No contract.".to_string()),
-        };
+        });
     }
 
-    match create_project(contract) {
-        Ok(project_name) => {
-            // Run charcoal on the file and capture the output.
-            let output = run_charcoal(contract_path(project_name.clone()));
-            let response = if !output.stderr.is_empty() {
-                let error: &str = std::str::from_utf8(&output.stderr).unwrap();
-                TranspileResponse {
-                    sway_contract: "".to_string(),
-                    error: Some(clean_error_content(error.to_string(), FILE_NAME)),
-                }
-            } else if !output.stdout.is_empty() {
-                let result = std::str::from_utf8(&output.stdout).unwrap();
+    let project_name =
+        create_project(contract).map_err(|_| ApiError::Filesystem("create project".into()))?;
 
-                // Replace the generated comments from charcoal with a custom comment.
-                let re = Regex::new(r"// Translated from.*").unwrap();
-                let replacement = "// Transpiled from Solidity using charcoal. Generated code may be incorrect or unoptimal.";
-                let sway_contract = re.replace_all(result, replacement).into_owned();
-
-                TranspileResponse {
-                    sway_contract,
-                    error: None,
-                }
-            } else {
-                TranspileResponse {
-                    sway_contract: "".to_string(),
-                    error: Some(
-                        "An unknown error occurred while transpiling the Solidity contract."
-                            .to_string(),
-                    ),
-                }
-            };
-
-            // Delete the temporary file.
-            if let Err(err) = remove_project(project_name.clone()) {
-                return TranspileResponse {
-                    sway_contract: String::from(""),
-                    error: Some(format!("Failed to remove temporary file: {err}")),
-                };
-            }
-
-            response
-        }
-        Err(err) => TranspileResponse {
+    // Run charcoal on the file and capture the output.
+    let output = run_charcoal(contract_path(project_name.clone()));
+    let response = if !output.stderr.is_empty() {
+        let error: &str =
+            std::str::from_utf8(&output.stderr).map_err(|e| ApiError::Charcoal(e.to_string()))?;
+        TranspileResponse {
             sway_contract: "".to_string(),
-            error: Some(format!("Failed to create temporary file: {err}")),
-        },
+            error: Some(clean_error_content(error.to_string(), FILE_NAME)),
+        }
+    } else if !output.stdout.is_empty() {
+        let result =
+            std::str::from_utf8(&output.stdout).map_err(|e| ApiError::Charcoal(e.to_string()))?;
+
+        // Replace the generated comments from charcoal with a custom comment.
+        let re =
+            Regex::new(r"// Translated from.*").map_err(|e| ApiError::Charcoal(e.to_string()))?;
+        let replacement = "// Transpiled from Solidity using charcoal. Generated code may be incorrect or unoptimal.";
+        let sway_contract = re.replace_all(result, replacement).into_owned();
+
+        TranspileResponse {
+            sway_contract,
+            error: None,
+        }
+    } else {
+        TranspileResponse {
+            sway_contract: "".to_string(),
+            error: Some(
+                "An unknown error occurred while transpiling the Solidity contract.".to_string(),
+            ),
+        }
+    };
+
+    // Delete the temporary file.
+    if let Err(err) = remove_project(project_name.clone()) {
+        return Ok(TranspileResponse {
+            sway_contract: String::from(""),
+            error: Some(format!("Failed to remove temporary file: {err}")),
+        });
     }
+
+    Ok(response)
 }
 
 fn create_project(contract: String) -> std::io::Result<String> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use rocket::serde::{Deserialize, Serialize};
 use std::fmt::{self};
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Language {
     Solidity,
@@ -50,18 +50,59 @@ pub struct CompileResponse {
     pub error: Option<String>,
 }
 
+/// A contract's code and its language. Used for contracts in languages other than Sway that can be transpiled.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ContractCode {
+    pub contract: String,
+    pub language: Language,
+}
+
 /// The transpile request.
 #[derive(Deserialize)]
 pub struct TranspileRequest {
-    pub contract: String,
-    pub lanaguage: Language,
+    #[serde(flatten)]
+    pub contract_code: ContractCode,
 }
 
-/// The response to a compile request.
+/// The response to a transpile request.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TranspileResponse {
     pub sway_contract: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The new gist request.
+#[derive(Deserialize)]
+pub struct NewGistRequest {
+    pub sway_contract: String,
+    pub transpile_contract: ContractCode,
+}
+
+/// Information about a gist.
+#[derive(Serialize, Deserialize)]
+pub struct GistMeta {
+    pub id: String,
+    pub url: String,
+}
+
+/// The response to a new gist request.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewGistResponse {
+    pub gist: GistMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The response to a gist request.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GistResponse {
+    pub gist: GistMeta,
+    pub sway_contract: String,
+    pub transpile_contract: ContractCode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-playground/issues/78

Pending devops PR for the new environment variable secret <TODO> 
To test it locally you need the secret as well.

- Adds a share button that, when clicked, generates a link to the playground containing a gist ID, toolchain name, and whether or not the transpile editor should be open.
- The gist includes both the sway code and solidity
- Improves error handling in the other APIs

### Share button and clicking the playground link

![May-09-2024 15-40-01](https://github.com/FuelLabs/sway-playground/assets/47993817/08fab2a3-6e04-421d-ba07-38dbb884a2fb)

### Link directly to the gist

![May-09-2024 15-40-19](https://github.com/FuelLabs/sway-playground/assets/47993817/751eee82-c8d1-467c-8b46-ee62ff234e73)
