### PR TITLE
chore: Remove ERC20 solidity example for now.

### DIFF
--- a/app/src/features/editor/examples/solidity/index.ts
+++ b/app/src/features/editor/examples/solidity/index.ts
@@ -1,11 +1,12 @@
 import { ExampleMenuItem } from "../../components/ExampleDropdown";
 import { EXAMPLE_SOLIDITY_CONTRACT_COUNTER } from "./counter";
-import { EXAMPLE_SOLIDITY_CONTRACT_ERC20 } from "./erc20";
+// import { EXAMPLE_SOLIDITY_CONTRACT_ERC20 } from "./erc20";
 import { EXAMPLE_SOLIDITY_CONTRACT_VOTING } from "./voting";
 
 export const EXAMPLE_SOLIDITY_CONTRACTS: ExampleMenuItem[] = [
     { label: 'Counter.sol', code: EXAMPLE_SOLIDITY_CONTRACT_COUNTER },
-    { label: 'ERC20.sol', code: EXAMPLE_SOLIDITY_CONTRACT_ERC20 },
+    // TODO: add this back once it works again with charcoal.
+    // { label: 'ERC20.sol', code: EXAMPLE_SOLIDITY_CONTRACT_ERC20 },
     { label: 'Voting.sol', code: EXAMPLE_SOLIDITY_CONTRACT_VOTING },
   ];
   


### PR DESCRIPTION
This change removes the ERC20 example from the dropdown list in the Solidity editor.

Currently, the generated sway from the latest version of charcoal for this example does not compile.

The error is: 

```
  --> /Users/sophiedankel/Development/sway-playground/projects/swaypad/src/main.sw:20:5
   |
18 | 
19 | impl AbiEncode for ERC20Event {
20 |     fn abi_encode(self, buffer: Buffer) {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected: Buffer 
found:    () 
help:     The definition of this function must match the one in the trait "AbiEncode" declaration.
21 |         match self {
22 |             ERC20Event::Approval((a, b, c)) => {
   |
____

  Aborting due to 1 error.
```

The issue is that the generated code for `abi_encode` does not return a value:

```
    fn abi_encode(self, buffer: core::codec::Buffer) {
```

Should be 
```
    fn abi_encode(self, buffer: core::codec::Buffer) -> core::codec::Buffer {
```
 Related https://github.com/ourovoros-io/charcoal/issues/2