### PR TITLE
fix: Always make dry run calls for read only functions

### DIFF
--- a/app/src/features/interact/components/FunctionToolbar.tsx
+++ b/app/src/features/interact/components/FunctionToolbar.tsx
@@ -5,6 +5,7 @@ import Toolbar from "@mui/material/Toolbar";
 import DryrunSwitch from "./DryrunSwitch";
 import { CallableParamValue } from "./FunctionParameters";
 import useTheme from "../../../context/theme";
+import { useContract } from "../hooks/useContract";
 
 interface FunctionToolbarProps {
   contractId: string;
@@ -22,10 +23,12 @@ function FunctionToolbar({
   updateLog,
 }: FunctionToolbarProps) {
   const [dryrun, setDryrun] = React.useState(true);
+  const { contract } = useContract(contractId);
+  const { themeColor } = useTheme();
 
   const title = parameters.length ? "Parameters" : "No Parameters";
 
-  const { themeColor } = useTheme();
+  const isReadOnly = !!contract?.functions[functionName].isReadOnly();
 
   return (
     <Toolbar style={{ padding: "0 2px 0", justifyContent: "space-between" }}>
@@ -38,7 +41,9 @@ function FunctionToolbar({
           flexDirection: "row",
         }}
       >
-        <DryrunSwitch dryrun={dryrun} onChange={() => setDryrun(!dryrun)} />
+        {!isReadOnly && (
+          <DryrunSwitch dryrun={dryrun} onChange={() => setDryrun(!dryrun)} />
+        )}
         <div style={{ float: "left" }}>
           <CallButton
             contractId={contractId}

--- a/app/src/features/interact/hooks/useCallFunction.ts
+++ b/app/src/features/interact/hooks/useCallFunction.ts
@@ -38,9 +38,10 @@ export function useCallFunction({
 
       if (!contract) throw new Error("Contract not connected");
 
-      const functionCaller = contract.functions[functionName](...parameters);
+      const functionHandle = contract.functions[functionName];
+      const functionCaller = functionHandle(...parameters);
       const transactionResult =
-        callType === "dryrun"
+        callType === "dryrun" || functionHandle.isReadOnly()
           ? await functionCaller.dryRun()
           : await functionCaller.call();
       return transactionResult;


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway-playground/issues/56

Hides the dry run switch for read-only functions, and always calls those functions in dry run mode.