### PR TITLE
Update Single and Multi Asset Example to match latest SRC-20 and SRC-3 specs

### DIFF
--- a/app/src/features/editor/examples/sway/multiasset.ts
+++ b/app/src/features/editor/examples/sway/multiasset.ts
@@ -2,7 +2,7 @@ export const EXAMPLE_SWAY_CONTRACT_MULTIASSET = `// ERC1155 equivalent in Sway.
 contract;
 
 use standards::src5::{AccessError, SRC5, State};
-use standards::src20::SRC20;
+use standards::src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
 use standards::src3::SRC3;
 use std::{
     asset::{
@@ -58,6 +58,7 @@ impl MultiAsset for Contract {
         require_access_owner();
         storage.name.insert(asset, StorageString {});
         storage.name.get(asset).write_slice(name);
+        SetNameEvent::new(asset, Some(name), msg_sender().unwrap()).log();
     }
 
     #[storage(read, write)]
@@ -65,12 +66,14 @@ impl MultiAsset for Contract {
         require_access_owner();
         storage.symbol.insert(asset, StorageString {});
         storage.symbol.get(asset).write_slice(symbol);
+        SetSymbolEvent::new(asset, Some(symbol), msg_sender().unwrap()).log();
     }
 
     #[storage(read, write)]
     fn set_decimals(asset: AssetId, decimals: u8) {
         require_access_owner();
         storage.decimals.insert(asset, decimals);
+        SetDecimalsEvent::new(asset, decimals, sender).log();
     }
 }
 
@@ -113,8 +116,12 @@ impl SRC20 for Contract {
 
 impl SRC3 for Contract {
     #[storage(read, write)]
-    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
         require_access_owner();
+        let sub_id = match sub_id {
+            Some(id) => id,
+            None => SubId::zero(),
+        };
         let asset_id = AssetId::new(ContractId::this(), sub_id);
         let supply = storage.total_supply.get(asset_id).try_read();
         if supply.is_none() {
@@ -127,6 +134,7 @@ impl SRC3 for Contract {
             .total_supply
             .insert(asset_id, current_supply + amount);
         mint_to(recipient, sub_id, amount);
+        TotalSupplyEvent::new(asset_id, current_supply + amount, msg_sender().unwrap()).log();
     }
 
     #[payable]
@@ -142,6 +150,7 @@ impl SRC3 for Contract {
             .total_supply
             .insert(asset_id, current_supply - amount);
         burn(sub_id, amount);
+        TotalSupplyEvent::new(asset_id, current_supply - amount, msg_sender().unwrap()).log();
     }
 }
 `;

--- a/app/src/features/editor/examples/sway/multiasset.ts
+++ b/app/src/features/editor/examples/sway/multiasset.ts
@@ -73,7 +73,7 @@ impl MultiAsset for Contract {
     fn set_decimals(asset: AssetId, decimals: u8) {
         require_access_owner();
         storage.decimals.insert(asset, decimals);
-        SetDecimalsEvent::new(asset, decimals, sender).log();
+        SetDecimalsEvent::new(asset, decimals, msg_sender().unwrap()).log();
     }
 }
 

--- a/app/src/features/editor/examples/sway/singleasset.ts
+++ b/app/src/features/editor/examples/sway/singleasset.ts
@@ -3,7 +3,7 @@ contract;
 
 use standards::src3::SRC3;
 use standards::src5::{AccessError, SRC5, State};
-use standards::src20::SRC20;
+use standards::src20::{SetDecimalsEvent, SetNameEvent, SetSymbolEvent, SRC20, TotalSupplyEvent};
 use std::{
     asset::{
         burn,
@@ -108,14 +108,16 @@ impl SRC5 for Contract {
 
 impl SRC3 for Contract {
     #[storage(read, write)]
-    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
-        require(sub_id == DEFAULT_SUB_ID, "incorrect-sub-id");
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
+        require(sub_id.is_some() && sub_id.unwrap() == DEFAULT_SUB_ID, "incorrect-sub-id");
         require_access_owner();
 
+        let current_supply = storage.total_supply.read();
         storage
             .total_supply
-            .write(amount + storage.total_supply.read());
+            .write(current_supply + amount);
         mint_to(recipient, DEFAULT_SUB_ID, amount);
+        TotalSupplyEvent::new(asset_id, current_supply + amount, msg_sender().unwrap()).log();
     }
 
     #[payable]
@@ -129,10 +131,31 @@ impl SRC3 for Contract {
         );
         require_access_owner();
 
+        let current_supply = storage.total_supply.read();
         storage
             .total_supply
-            .write(storage.total_supply.read() - amount);
+            .write(current_supply - amount);
         burn(DEFAULT_SUB_ID, amount);
+        TotalSupplyEvent::new(asset_id, current_supply - amount, msg_sender().unwrap()).log();
+    }
+}
+
+abi EmitSRC20Events {
+    fn emit_src20_events();
+}
+
+impl EmitSRC20Events for Contract {
+    fn emit_src20_events() {
+        // Metadata that is stored as a configurable should only be emitted once.
+        let asset = AssetId::default();
+        let sender = msg_sender().unwrap();
+        let name = Some(String::from_ascii_str(from_str_array(NAME)));
+        let symbol = Some(String::from_ascii_str(from_str_array(SYMBOL)));
+
+        SetNameEvent::new(asset, name, sender).log();
+        SetSymbolEvent::new(asset, symbol, sender).log();
+        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
     }
 }
 `;

--- a/app/src/features/editor/examples/sway/singleasset.ts
+++ b/app/src/features/editor/examples/sway/singleasset.ts
@@ -117,7 +117,7 @@ impl SRC3 for Contract {
             .total_supply
             .write(current_supply + amount);
         mint_to(recipient, DEFAULT_SUB_ID, amount);
-        TotalSupplyEvent::new(asset_id, current_supply + amount, msg_sender().unwrap()).log();
+        TotalSupplyEvent::new(AssetId::default(), current_supply + amount, msg_sender().unwrap()).log();
     }
 
     #[payable]
@@ -136,7 +136,7 @@ impl SRC3 for Contract {
             .total_supply
             .write(current_supply - amount);
         burn(DEFAULT_SUB_ID, amount);
-        TotalSupplyEvent::new(asset_id, current_supply - amount, msg_sender().unwrap()).log();
+        TotalSupplyEvent::new(AssetId::default(), current_supply - amount, msg_sender().unwrap()).log();
     }
 }
 
@@ -155,7 +155,6 @@ impl EmitSRC20Events for Contract {
         SetNameEvent::new(asset, name, sender).log();
         SetSymbolEvent::new(asset, symbol, sender).log();
         SetDecimalsEvent::new(asset, DECIMALS, sender).log();
-        TotalSupplyEvent::new(asset, TOTAL_SUPPLY, sender).log();
     }
 }
 `;

--- a/projects/swaypad/Forc.toml
+++ b/projects/swaypad/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "swaypad"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }


### PR DESCRIPTION
## Changes

- The SRC-20 specs have been updated to include logging for Name, Symbol, Decimals, and Total supply. This has been added to the single and multi asset examples to match the specs.
- The SRC-3 specs have been updated to include an `Option` as part of the `sub_id` argument. The single and multi asset examples have been updated to match the specs
- The Sway-Standards version has been updated to v0.6.1