### PR TITLE
fix: update charcoal version

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -20,7 +20,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef as builder
 
 # Install charcoal
-RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev 77954dd00e9097ace2ee794759a098898f446e1e
+RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev e69a6ffaf3e7eaf9f3ceea543087ea59ec5fd5d1
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.76 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.81 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 
@@ -20,7 +20,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef as builder
 
 # Install charcoal
-RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev 527ea29eca1ebffa46ffe370354005d936989810
+RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev e69a6ffaf3e7eaf9f3ceea543087ea59ec5fd5d1
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -20,7 +20,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef as builder
 
 # Install charcoal
-RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev e69a6ffaf3e7eaf9f3ceea543087ea59ec5fd5d1
+RUN cargo install --git https://github.com/ourovoros-io/charcoal.git --rev 527ea29eca1ebffa46ffe370354005d936989810
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json


### PR DESCRIPTION
Currently the solidity transpiler is failing with `WARNING: no support for delegatecall, this, ASM, strings. Coming soon in future releases.` This PR updates the version to the latest commit.