### PR TITLE
fix: update server URI to fuel.network

### DIFF
--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,5 +1,5 @@
 const SERVER_API =
-  process.env.REACT_APP_SERVER_API || "https://testnet-api.sway-playground.org";
+  process.env.REACT_APP_SERVER_API || "https://api.sway-playground.fuel.network";
 
 export const FUEL_GREEN = "#00f58c";
 export const LOCAL_SERVER_URI = "http://0.0.0.0:8080";

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,8 +1,9 @@
 const SERVER_API =
-  process.env.REACT_APP_SERVER_API || "https://api.sway-playground.fuel.network";
+  process.env.REACT_APP_SERVER_API ||
+  'https://api.sway-playground.fuel.network';
 
-export const FUEL_GREEN = "#00f58c";
-export const LOCAL_SERVER_URI = "http://0.0.0.0:8080";
+export const FUEL_GREEN = '#00f58c';
+export const LOCAL_SERVER_URI = 'http://0.0.0.0:8080';
 export const SERVER_URI = process.env.REACT_APP_LOCAL_SERVER
   ? LOCAL_SERVER_URI
   : SERVER_API;

--- a/app/src/constants.ts
+++ b/app/src/constants.ts
@@ -1,9 +1,9 @@
 const SERVER_API =
   process.env.REACT_APP_SERVER_API ||
-  'https://api.sway-playground.fuel.network';
+  "https://api.sway-playground.fuel.network";
 
-export const FUEL_GREEN = '#00f58c';
-export const LOCAL_SERVER_URI = 'http://0.0.0.0:8080';
+export const FUEL_GREEN = "#00f58c";
+export const LOCAL_SERVER_URI = "http://0.0.0.0:8080";
 export const SERVER_URI = process.env.REACT_APP_LOCAL_SERVER
   ? LOCAL_SERVER_URI
   : SERVER_API;


### PR DESCRIPTION
There's an issue with the old URI's SSL cert, but the fuel.network cert is working.

Updated the env var here: https://sway-playground-ns7rtk87s-fuel-labs.vercel.app/#