### PR TITLE
Add sway_libs to sway playground

### DIFF
--- a/projects/swaypad/Forc.toml
+++ b/projects/swaypad/Forc.toml
@@ -6,3 +6,4 @@ name = "swaypad"
 
 [dependencies]
 standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.1" }

--- a/projects/swaypad/Forc.toml
+++ b/projects/swaypad/Forc.toml
@@ -6,4 +6,4 @@ name = "swaypad"
 
 [dependencies]
 standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.0" }


### PR DESCRIPTION
## Abstract

This PR adds Sway Libs an essential library for most Sway developers to Sway Playground.