### PR TITLE
feat/ Make dry run toggle live by default and add tooltip

### DIFF
--- a/app/src/components/SecondaryButton.tsx
+++ b/app/src/components/SecondaryButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
 import useTheme from "../context/theme";
@@ -11,6 +11,7 @@ export interface SecondaryButtonProps {
   tooltip?: string;
   style?: React.CSSProperties;
   header?: boolean;
+  live?: boolean;
 }
 function SecondaryButton({
   onClick,
@@ -20,6 +21,7 @@ function SecondaryButton({
   tooltip,
   style,
   header,
+  live = false,
 }: SecondaryButtonProps) {
   if (header) {
     style = {
@@ -32,6 +34,12 @@ function SecondaryButton({
   }
 
   const { themeColor } = useTheme();
+
+  useEffect(() => {
+    if (live) {
+      onClick();
+    }
+  }, [live, onClick]);
 
   return (
     <Tooltip title={tooltip}>

--- a/app/src/features/toolbar/components/ActionToolbar.tsx
+++ b/app/src/features/toolbar/components/ActionToolbar.tsx
@@ -100,6 +100,7 @@ function ActionToolbar({
             ? "Hide the Solidity editor"
             : "Show the Solidity editor to transpile Solidity to Sway"
         }
+        live={true}
       />
       <SecondaryButton
         header={true}


### PR DESCRIPTION
Issue Details: The issue [#110](https://github.com/FuelLabs/sway-playground/issues/110) requires making the dry run toggle live by default and adding a tooltip.

- Modify the dry run toggle to make it live by default.
- Add or update the tooltip for the dry run toggle feature.