### PR TITLE
chore: update Sway libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sway Playground is built in Rust and Javascript. To begin, install the Rust tool
 rustup default stable
 ```
 
-If you haven't already, add the Cargo bin directory to your `PATH` by adding the following line to `~/.profile` and restarting the shell session.
+If not already done, add the Cargo bin directory to your `PATH` by adding the following line to `~/.profile` and restarting the shell session.
 
 ```sh
 export PATH="${HOME}/.cargo/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sway Playground is built in Rust and Javascript. To begin, install the Rust tool
 rustup default stable
 ```
 
-If not already done, add the Cargo bin directory to your `PATH` by adding the following line to `~/.profile` and restarting the shell session.
+If you haven't already, add the Cargo bin directory to your `PATH` by adding the following line to `~/.profile` and restarting the shell session.
 
 ```sh
 export PATH="${HOME}/.cargo/bin:${PATH}"

--- a/projects/swaypad/Forc.lock
+++ b/projects/swaypad/Forc.lock
@@ -1,16 +1,19 @@
 [[package]]
-name = "core"
-source = "path+from-root-148AAAB4460F1A9D"
-
-[[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.4#a001d3c248595112aae67e5633a06ef9bc0536ae"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.7.0#7d35df95e0b96dc8ad188ab169fbbeeac896aae8"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.59.0#d9985d8111f94235edba9a08fc71a9513ec2a95c"
-dependencies = ["core"]
+source = "git+https://github.com/fuellabs/sway?tag=v0.67.0#d821dcb0c7edb1d6e2a772f5a1ccefe38902eaec"
+
+[[package]]
+name = "sway_libs"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.25.1#00569f811eae256a522c0e592522ea638815b362"
+dependencies = [
+    "standards",
+    "std",
+]
 
 [[package]]
 name = "swaypad"
@@ -18,4 +21,5 @@ source = "member"
 dependencies = [
     "standards",
     "std",
+    "sway_libs",
 ]

--- a/projects/swaypad/Forc.toml
+++ b/projects/swaypad/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "swaypad"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.1" }


### PR DESCRIPTION
This pull request updates the dependencies in the `Forc.toml` file for the `swaypad` project to use newer versions of `standards` and `sway_libs`.

Dependency updates:

* Updated `standards` dependency to version `v0.7.0` from `v0.6.1`.
* Updated `sway_libs` dependency to version `v0.25.1` from `v0.24.0`.